### PR TITLE
fix: Don't yield bonus items from mem. iterator post delete

### DIFF
--- a/memory/iter.go
+++ b/memory/iter.go
@@ -133,6 +133,11 @@ func (iter *dsPrefixIter) loadLatestItem() {
 	}
 
 	if curItem.isDeleted {
+		iter.curItem = nil
+
+		if iter.it.Next() {
+			iter.loadLatestItem()
+		}
 		return
 	}
 	iter.curItem = &curItem

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -237,6 +237,11 @@ func (iter *dsRangeIter) loadLatestItem() {
 	}
 
 	if curItem.isDeleted {
+		iter.curItem = nil
+
+		if iter.it.Next() {
+			iter.loadLatestItem()
+		}
 		return
 	}
 	iter.curItem = &curItem

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -52,10 +52,6 @@ func newPrefixIter(ctx context.Context, db *Datastore, prefix []byte, reverse bo
 		pIter.Seek(prefix)
 	}
 
-	// load first item. Seek will also load, so this may be a duplicate
-	// action, but this is idempotent so its OK.
-	pIter.loadLatestItem()
-
 	// if the first key is an exact match to the prefix, skip next
 	// since prefix is a *strict* subset prefix
 	if pIter.curItem != nil && bytes.Equal(pIter.Key(), prefix) {

--- a/test/integration/iterator/delete_test.go
+++ b/test/integration/iterator/delete_test.go
@@ -5,14 +5,10 @@ import (
 
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
-func TestIteratorDelete_Badger(t *testing.T) {
+func TestIteratorDelete(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), nil),
@@ -33,23 +29,36 @@ func TestIteratorDelete_Badger(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIteratorDelete_Memory(t *testing.T) {
+func TestIteratorDelete_DeleteLastItem(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), nil),
 			action.Set([]byte("k4"), []byte("v4")),
 			action.Set([]byte("k2"), []byte("v2")),
-			action.Delete([]byte("k2")),
+			action.Delete([]byte("k4")),
 			&action.Iterate{
 				Expected: []action.KeyValue{
 					{Key: []byte("k1"), Value: []byte("v1")},
-					{Key: []byte("k1"), Value: []byte("v1")}, // `k1` is returned twice!
+					{Key: []byte("k2"), Value: []byte("v2")},
 					{Key: []byte("k3"), Value: nil},
-					{Key: []byte("k4"), Value: []byte("v4")},
+					// `k4` should not be returned
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorDelete_DeleteOnlyItem(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Delete([]byte("k4")),
+			&action.Iterate{
+				Expected: []action.KeyValue{
+					// `k4` should not be returned
 				},
 			},
 		},

--- a/test/integration/iterator/delete_test.go
+++ b/test/integration/iterator/delete_test.go
@@ -1,0 +1,59 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorDelete_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.Delete([]byte("k2")),
+			&action.Iterate{
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1")},
+					// `k2` should not be returned
+					{Key: []byte("k3"), Value: nil},
+					{Key: []byte("k4"), Value: []byte("v4")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorDelete_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.Delete([]byte("k2")),
+			&action.Iterate{
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1")},
+					{Key: []byte("k1"), Value: []byte("v1")}, // `k1` is returned twice!
+					{Key: []byte("k3"), Value: nil},
+					{Key: []byte("k4"), Value: []byte("v4")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/prefix_delete_test.go
+++ b/test/integration/iterator/prefix_delete_test.go
@@ -1,0 +1,78 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorPrefixDelete(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.Delete([]byte("k2")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					// `1` must not be yielded
+					// `k2` must not be yielded
+					{Key: []byte("k3"), Value: nil},
+					// `4` must not be yielded
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorPrefixDelete_DeleteLastItem(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.Delete([]byte("k3")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					// `1` must not be yielded
+					{Key: []byte("k2"), Value: []byte("v2")},
+					// `k3` must not be yielded
+					// `4` must not be yielded
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorPrefixDelete_DeleteOnlyItem(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Delete([]byte("k4")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					// `k4` should not be returned
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves https://github.com/sourcenetwork/corekv/issues/9

## Description

Changes the code so that the memory iterator doesn't return previous item twice when iterating over deleted items.  Also adds tests for this case.

Please do not review the first commit here.

I suggest reviewing commit by commit, the messages contain extra context, and the first commit documents the existing buggy behaviour.