### PR TITLE
test: Introduce iterator test action

### DIFF
--- a/test/action/iterator.go
+++ b/test/action/iterator.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Iterate action will create an iterator, execute the given child actions on the iterator,
-// then release the iterator when this action is executed.
+// Iterator action will create an iterator, execute the given child actions on the iterator,
+// then release the iterator when this [Iterator] action is executed.
 type Iterator struct {
 	corekv.IterOptions
 

--- a/test/action/iterator.go
+++ b/test/action/iterator.go
@@ -1,0 +1,99 @@
+package action
+
+import (
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/state"
+	"github.com/stretchr/testify/require"
+)
+
+// Iterate action will create an iterator, execute the given child actions on the iterator,
+// then release the iterator when this action is executed.
+type Iterator struct {
+	corekv.IterOptions
+
+	// The actions to execute on the created iterator.
+	Actions []IteratorAction
+}
+
+var _ Action = (*Iterator)(nil)
+
+func (a *Iterator) Execute(s *state.State) {
+	iterator := s.Store.Iterator(s.Ctx, a.IterOptions)
+
+	for _, action := range a.Actions {
+		action.Execute(s, iterator)
+	}
+
+	err := iterator.Close(s.Ctx)
+	require.NoError(s.T, err)
+}
+
+// IteratorAction types will execute as part of an [Iterator] action.
+type IteratorAction interface {
+	Execute(s *state.State, iterator corekv.Iterator)
+}
+
+// SeekTo executes a single `Seek` call on an [Iterator].
+type SeekTo struct {
+	// The target key to seek to.
+	Target []byte
+}
+
+var _ IteratorAction = (*SeekTo)(nil)
+
+// Seek returns a [SeekTo] iterator action that executes a single `Seek` call
+// on an [Iterator] to the given target.
+func Seek(target []byte) *SeekTo {
+	return &SeekTo{
+		Target: target,
+	}
+}
+
+func (a *SeekTo) Execute(s *state.State, iterator corekv.Iterator) {
+	iterator.Seek(a.Target)
+}
+
+// Valid executes a single `Valid` call on an [Iterator] and requires that
+// the returned result matches the given `Expected` value.
+type Valid struct {
+	// The expected result of the `Valid` call.
+	Expected bool
+}
+
+var _ IteratorAction = (*Valid)(nil)
+
+// IsValid returns a [Valid] iterator action that executes a single `Valid` call
+// on an [Iterator] and requires that the returned result is true.
+func IsValid() *Valid {
+	return &Valid{
+		Expected: true,
+	}
+}
+
+// IsInvalid returns a [Valid] iterator action that executes a single `Valid` call
+// on an [Iterator] and requires that the returned result is false.
+func IsInvalid() *Valid {
+	return &Valid{
+		Expected: false,
+	}
+}
+
+func (a *Valid) Execute(s *state.State, iterator corekv.Iterator) {
+	result := iterator.Valid()
+	require.Equal(s.T, a.Expected, result)
+}
+
+// MoveNext executes a single `Next` call on an an [Iterator].
+type MoveNext struct{}
+
+var _ IteratorAction = (*MoveNext)(nil)
+
+// Next returns a [MoveNext] iterator action that executes a single `Next` call
+// on an [Iterator].
+func Next() *MoveNext {
+	return &MoveNext{}
+}
+
+func (a *MoveNext) Execute(s *state.State, iterator corekv.Iterator) {
+	iterator.Next()
+}

--- a/test/action/iterator.go
+++ b/test/action/iterator.go
@@ -12,7 +12,7 @@ type Iterator struct {
 	corekv.IterOptions
 
 	// The actions to execute on the created iterator.
-	Actions []IteratorAction
+	ChildActions []IteratorAction
 }
 
 var _ Action = (*Iterator)(nil)
@@ -20,7 +20,7 @@ var _ Action = (*Iterator)(nil)
 func (a *Iterator) Execute(s *state.State) {
 	iterator := s.Store.Iterator(s.Ctx, a.IterOptions)
 
-	for _, action := range a.Actions {
+	for _, action := range a.ChildActions {
 		action.Execute(s, iterator)
 	}
 

--- a/test/integration/iterator/prefix_reverse_valid_test.go
+++ b/test/integration/iterator/prefix_reverse_valid_test.go
@@ -21,7 +21,7 @@ func TestIteratorPrefixReverseValid_Badger(t *testing.T) {
 					Reverse: true,
 					Prefix:  []byte("k"),
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsValid(),
 				},
 			},
@@ -45,7 +45,7 @@ func TestIteratorPrefixReverseValid_Memory(t *testing.T) {
 					Reverse: true,
 					Prefix:  []byte("k"),
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsInvalid(),
 				},
 			},

--- a/test/integration/iterator/prefix_reverse_valid_test.go
+++ b/test/integration/iterator/prefix_reverse_valid_test.go
@@ -1,0 +1,56 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorPrefixReverseValid_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Prefix:  []byte("k"),
+				},
+				Actions: []action.IteratorAction{
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents undesirable behaviour, issue:
+// https://github.com/sourcenetwork/corekv/issues/11
+func TestIteratorPrefixReverseValid_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Prefix:  []byte("k"),
+				},
+				Actions: []action.IteratorAction{
+					action.IsInvalid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_next_valid_test.go
+++ b/test/integration/iterator/reverse_next_valid_test.go
@@ -26,7 +26,7 @@ func TestIteratorReverseNextValid_Badger(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Next(),
 					action.Next(),
 					action.Next(),
@@ -64,7 +64,7 @@ func TestIteratorReverseNextValid_MemoryUnnamespaced(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Next(),
 					action.Next(),
 					action.Next(),
@@ -98,7 +98,7 @@ func TestIteratorReverseNextValid_MemoryNamespaced(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsInvalid(),
 					action.Next(),
 					action.IsValid(),

--- a/test/integration/iterator/reverse_next_valid_test.go
+++ b/test/integration/iterator/reverse_next_valid_test.go
@@ -1,0 +1,122 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+	"github.com/stretchr/testify/require"
+)
+
+// This test documents undesirable behaviour, issue:
+// https://github.com/sourcenetwork/corekv/issues/19
+func TestIteratorReverseNextValid_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.Next(),
+					action.Next(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsInvalid(),
+					action.Next(),
+					action.IsInvalid(),
+				},
+			},
+		},
+	}
+
+	require.PanicsWithError(
+		t,
+		"runtime error: invalid memory address or nil pointer dereference",
+		func() {
+			test.Execute(t)
+		},
+	)
+}
+
+func TestIteratorReverseNextValid_MemoryUnnamespaced(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.ManualOnly,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.Next(),
+					action.Next(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsInvalid(),
+					action.Next(),
+					action.IsInvalid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents undesirable behaviour, issue:
+// https://github.com/sourcenetwork/corekv/issues/11
+func TestIteratorReverseNextValid_MemoryNamespaced(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.AutomaticForced,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.IsInvalid(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsValid(),
+					// etc...
+					// The first call(s) to `Valid` will return false, and then will forever return `true`
+					// on item iteration
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_seek_next_valid_test.go
+++ b/test/integration/iterator/reverse_seek_next_valid_test.go
@@ -19,7 +19,7 @@ func TestIteratorReverseSeekNextValid(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Seek([]byte("k2")),
 					action.Next(),
 					action.IsValid(),

--- a/test/integration/iterator/reverse_seek_next_valid_test.go
+++ b/test/integration/iterator/reverse_seek_next_valid_test.go
@@ -1,0 +1,32 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorReverseSeekNextValid(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.Seek([]byte("k2")),
+					action.Next(),
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_seek_valid_test.go
+++ b/test/integration/iterator/reverse_seek_valid_test.go
@@ -1,0 +1,31 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorReverseSeekValid(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.Seek([]byte("k2")),
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_seek_valid_test.go
+++ b/test/integration/iterator/reverse_seek_valid_test.go
@@ -19,7 +19,7 @@ func TestIteratorReverseSeekValid(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Seek([]byte("k2")),
 					action.IsValid(),
 				},

--- a/test/integration/iterator/reverse_start_next_valid_test.go
+++ b/test/integration/iterator/reverse_start_next_valid_test.go
@@ -24,7 +24,7 @@ func TestIteratorReverseStartNextValid_Badger(t *testing.T) {
 					Reverse: true,
 					Start:   []byte("k2"),
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Next(),
 					action.Next(),
 					action.IsValid(),
@@ -56,7 +56,7 @@ func TestIteratorReverseStartNextValid_MemoryUnnamespaced(t *testing.T) {
 					Reverse: true,
 					Start:   []byte("k2"),
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Next(),
 					action.Next(),
 					action.IsValid(),
@@ -90,7 +90,7 @@ func TestIteratorReverseStartNextValid_MemoryNamespaced(t *testing.T) {
 					Reverse: true,
 					Start:   []byte("k2"),
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.Next(),
 					action.Next(),
 					action.IsValid(),

--- a/test/integration/iterator/reverse_start_next_valid_test.go
+++ b/test/integration/iterator/reverse_start_next_valid_test.go
@@ -1,0 +1,109 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorReverseStartNextValid_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Start:   []byte("k2"),
+				},
+				Actions: []action.IteratorAction{
+					action.Next(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsInvalid(),
+					action.Next(),
+					action.IsInvalid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorReverseStartNextValid_MemoryUnnamespaced(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.ManualOnly,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Start:   []byte("k2"),
+				},
+				Actions: []action.IteratorAction{
+					action.Next(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsInvalid(),
+					action.Next(),
+					action.IsInvalid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents undesirable behaviour, issue:
+// https://github.com/sourcenetwork/corekv/issues/11
+func TestIteratorReverseStartNextValid_MemoryNamespaced(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.AutomaticForced,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Start:   []byte("k2"),
+				},
+				Actions: []action.IteratorAction{
+					action.Next(),
+					action.Next(),
+					action.IsValid(),
+					action.Next(),
+					action.IsInvalid(),
+					action.Next(),
+					// Calling `Next` on an iterator that has already reached the end
+					// should not result in a valid item being yielded!
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_valid_test.go
+++ b/test/integration/iterator/reverse_valid_test.go
@@ -1,0 +1,77 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorReverseValid_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorReverseValid_MemoryUnnamespaced(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.ManualOnly,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents undesirable behaviour, issue:
+// https://github.com/sourcenetwork/corekv/issues/11
+func TestIteratorReverseValid_MemoryNamespaced(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.AutomaticForced,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Actions: []action.IteratorAction{
+					action.IsInvalid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_valid_test.go
+++ b/test/integration/iterator/reverse_valid_test.go
@@ -20,7 +20,7 @@ func TestIteratorReverseValid_Badger(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsValid(),
 				},
 			},
@@ -42,7 +42,7 @@ func TestIteratorReverseValid_MemoryUnnamespaced(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsValid(),
 				},
 			},
@@ -66,7 +66,7 @@ func TestIteratorReverseValid_MemoryNamespaced(t *testing.T) {
 				IterOptions: corekv.IterOptions{
 					Reverse: true,
 				},
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsInvalid(),
 				},
 			},

--- a/test/integration/iterator/valid_test.go
+++ b/test/integration/iterator/valid_test.go
@@ -1,0 +1,23 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorValid(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				Actions: []action.IteratorAction{
+					action.IsValid(),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/valid_test.go
+++ b/test/integration/iterator/valid_test.go
@@ -12,7 +12,7 @@ func TestIteratorValid(t *testing.T) {
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			&action.Iterator{
-				Actions: []action.IteratorAction{
+				ChildActions: []action.IteratorAction{
 					action.IsValid(),
 				},
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #16 

## Description

Introduces a new action allowing more complex testing of iterator operations than the exiting, simpler `Iterate` action.  Also adds a handful of tests using the new action, further documenting and existing bug and a new minor one.

Reviewers, consider focusing on the new action, not the tests - the tests added were largely in support of https://github.com/sourcenetwork/corekv/issues/11 and do not yet provide full coverage.