### PR TITLE
ci: Add job to run tests in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Relevant issue(s)
+
+Resolves #
+
+## Description
+
+(*replace*) Include a summary of the changes. List the issue(s) it solves in the section above, and
+create one if none exists.  Include relevant motivation and context. Detail new dependencies required for this change.
+
+## Tasks
+
+- [ ] I made sure the code is well commented, particularly hard-to-understand areas.
+- [ ] I made sure the repository-held documentation is changed accordingly.
+- [ ] I made sure the pull request title adheres to the conventional commit style (the subset used in the project can be found in [tools/configs/validate-conventional-style.sh](tools/configs/validate-conventional-style.sh).
+- [ ] I made sure to discuss its limitations such as threats to validity, vulnerability to mistake and misuse, robustness to invalidation of assumptions, resource requirements, ...
+
+## How has this been tested?
+
+(*replace*) Describe the tests performed to verify the changes. Provide instructions to reproduce them.
+
+Specify the platform(s) on which this was tested:
+- *(modify the list accordingly*)
+- Arch Linux
+- Debian Linux
+- MacOS
+- Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    name: Run tests job
+
+    strategy:
+        matrix:
+          os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v3
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.21"
+          check-latest: true
+
+      - name: Build dependencies
+        run: |
+          make deps:test-ci
+
+      - name: Run tests
+        run: make test:ci

--- a/.github/workflows/validate-title.yml
+++ b/.github/workflows/validate-title.yml
@@ -1,0 +1,27 @@
+name: Validate Title Workflow
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  validate-title:
+    name: Validate title job
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v3
+
+      - name: Ensure the scripts are not broken
+        run: make test:scripts
+
+      - name: Run the validation script on the title
+        run: ./tools/scripts/validate-conventional-style.sh "${{ github.event.pull_request.title }}"

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,7 @@ test\:ci:
 # We do not make the deps here, the ci does that seperately to avoid compiling stuff
 # multiple times etc.
 	gotestsum --format testname ./...
+
+.PHONY: test\:scripts
+test\:scripts:
+	@$(MAKE) -C ./tools/scripts/ test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: deps\:test-ci
+deps\:test-ci:
+	go install gotest.tools/gotestsum@latest
+
+.PHONY: clean
+clean:
+	go clean -testcache
+
+.PHONY: test
+test:
+	@$(MAKE) clean
+	go test ./...
+
+.PHONY: test\:ci
+test\:ci:
+# We do not make the deps here, the ci does that seperately to avoid compiling stuff
+# multiple times etc.
+	gotestsum --format testname ./...

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -1,0 +1,5 @@
+# Makefile for scripts.
+
+.PHONY: test
+test:
+	./scripts_test.sh

--- a/tools/scripts/scripts_test.sh
+++ b/tools/scripts/scripts_test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# TestReturnCode prints Pass if the expected return code matches the
+#  evaluated command, otherwise prints false and exits on first failure.
+# Usage: <Command> <ExpectedReturnCode>
+# Example: TestReturnCode "cat a.txt" 0
+TestReturnCode() {
+    eval "${1}" &> /dev/null;
+
+    local ACTUAL="${?}";
+    local EXPECTED="${2}";
+
+    if [ "${ACTUAL}" -eq "${EXPECTED}" ]; then
+        printf "PASS\n";
+    else
+        printf "FAIL ...\n";
+        printf "> Command  : [%s] \n" "${1}";
+        printf "> Expected : [%s] \n" "${EXPECTED}";
+        printf "> ACTUAL   : [%s] \n" "${ACTUAL}";
+        exit 1;
+    fi
+}
+
+# Test the script that is responsible for the validation of pr title.
+readonly T1="./validate-conventional-style.sh"
+
+TestReturnCode "${T1}" 2;
+
+TestReturnCode "${T1} 'chore: This title  has  everything     valid except that    its too long'" 3;
+TestReturnCode "${T1} 'bot Bump github.com/alternativesourcenetwork/defradb from 1.1.0.1.0.0 to 1.1.0.1.0.1'" 3;
+
+TestReturnCode "${T1} 'chore: This title has more than one : colon'" 4;
+TestReturnCode "${T1} 'chore This title has no colon'" 4;
+TestReturnCode "${T1} 'bot Bump github.com/short/short from 1.2.3 to 1.2.4'" 4; 
+
+TestReturnCode "${T1} 'feat: a'" 5;
+TestReturnCode "${T1} 'feat: '" 5;
+TestReturnCode "${T1} 'feat:'" 5;
+
+TestReturnCode "${T1} 'feat:There is no space between label & desc.'" 6;
+TestReturnCode "${T1} 'feat:there is no space between label & desc.'" 6;
+
+TestReturnCode "${T1} 'ci: lowercase first character after label'" 7;
+
+TestReturnCode "${T1} 'ci: Last character should not be period.'" 8;
+TestReturnCode "${T1} 'ci(i): Last character should not be period.'" 8;
+TestReturnCode "${T1} 'ci: Last character is a space '" 8;
+TestReturnCode "${T1} 'ci: Last character is a \\\`tick\\\`'" 8;
+
+TestReturnCode "${T1} 'bug: This is an invalid label'" 9;
+TestReturnCode "${T1} 'bug(i): This is an invalid label'" 9;
+
+TestReturnCode "${T1} 'ci: Last character is a number v1.5.0'" 0;
+TestReturnCode "${T1} 'ci: Last character is not lowercase alphabeT'" 0;
+TestReturnCode "${T1} 'chore: This is a valid title'" 0;
+TestReturnCode "${T1} 'ci: This is a valid title'" 0;
+TestReturnCode "${T1} 'docs: This is a valid title'" 0;
+TestReturnCode "${T1} 'feat: This is a valid title'" 0;
+TestReturnCode "${T1} 'fix: This is a valid title'" 0;
+TestReturnCode "${T1} 'perf: This is a valid title'" 0;
+TestReturnCode "${T1} 'refactor: This is a valid title'" 0;
+TestReturnCode "${T1} 'test: This is a valid title'" 0;
+TestReturnCode "${T1} 'tools: This is a valid title'" 0;
+TestReturnCode "${T1} 'bot: Bump github.com/alternativesourcenetwork/defradb from 1.1.0.1.0.0 to 1.1.0.1.0.1'" 0;
+TestReturnCode "${T1} 'ci(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'chore(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'docs(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'feat(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'fix(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'perf(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'refactor(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'test(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'tools(i): Valid ignore title'" 0;
+TestReturnCode "${T1} 'bot(i): Bump github.com/alternativesourcenetwork/defradb from 1.1.0.1.0.0 to 1.1.0.1.0.1'" 0;
+TestReturnCode "${T1} 'bot(i): Bump githurk/defradb from 1.1.0.1.0.0 to 1.1.0.1.0.1'" 0;

--- a/tools/scripts/validate-conventional-style.sh
+++ b/tools/scripts/validate-conventional-style.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+#========================================================================================
+# Script that would validate that the given string of commit or pull request title,
+#  adheres to our sub-set of conventional style commit labels. In addition to that also
+#  makes sure that the first letter after the `:` separator is capitalized.
+# Usage: ./validate-conventional-style.sh "feat: Add a new feature"
+#========================================================================================
+
+readonly BOT_LABEL="bot";
+readonly IGNORE_DECORATOR="(i)";
+
+# Declare a non-mutable indexed array that contains all the subset of conventional style
+#  labels that we deem valid for our use case. There should always be insync with the
+#  labels we have defined for the change log in: `defradb/tools/configs/chglog/config.yml`.
+readonly -a VALID_LABELS=("chore"
+                          "ci"
+                          "docs"
+                          "feat"
+                          "fix"
+                          "perf"
+                          "refactor"
+                          "test"
+                          "tools"
+                          "${BOT_LABEL}");
+
+if [ "${#}" -ne 1 ]; then
+    printf "Error: Invalid number of arguments (pass title as 1 string argument).\n";
+    exit 2;
+fi
+
+readonly TITLE="${1}";
+
+# Detect if title is prefixed with `bot`, skips length validation if it is.
+if [[ "${TITLE}" =~ ^"${BOT_LABEL}:" ]] || [[ "${TITLE}" =~ ^"${BOT_LABEL}${IGNORE_DECORATOR}:" ]]; then
+    printf "Info: Title is from a bot, skipping length-related title validation.\n";
+
+# Validate that the entire length of the title is less than or equal to our character limit.
+elif [[ "${#TITLE}" -gt 60 ]]; then
+    printf "Error: The length of the title is too long (should be 60 or less).\n";
+    exit 3;
+fi
+
+# Split the title at ':' and store the result in ${SPLIT_TOKENS}.
+# Doing eval to ensure the split works for elements that contain spaces.
+eval "SPLIT_TOKENS=($(echo "\"${TITLE}\"" | sed 's/:/" "/g'))";
+
+# Validate the `:` token exists exactly once.
+if [ "${#SPLIT_TOKENS[*]}" -ne 2 ]; then
+    printf "Error: Splitting title at ':' didn't result in 2 elements.\n";
+    exit 4;
+fi
+
+readonly LABEL="${SPLIT_TOKENS[0]}";
+readonly DESCRIPTION="${SPLIT_TOKENS[1]}";
+
+printf "Info: label = [%s]\n" "${LABEL}";
+printf "Info: description = [%s]\n" "${DESCRIPTION}";
+
+# Validate that description isn't too short.
+if [ "${#DESCRIPTION}" -le 2 ]; then
+    printf "Error: Description is too short.\n";
+    exit 5;
+fi
+
+readonly CHECK_SPACE="${DESCRIPTION::1}"; # First character
+readonly CHECK_FIRST_UPPER_CASE="${DESCRIPTION:1:1}"; # Second character
+readonly CHECK_LAST_VALID="${DESCRIPTION: -1}"; # Last character
+
+# Validate that there is a space between the label and description.
+if [ "${CHECK_SPACE}" != " " ]; then
+    printf "Error: There is no space between label and description.\n";
+    exit 6;
+fi
+
+# Validate that the first character after the label + ' ' is an uppercase alphabet character.
+if [[ "${CHECK_FIRST_UPPER_CASE}" != [A-Z] ]]; then
+    printf "Error: First character after the label is not an uppercase alphabet.\n";
+    exit 7;
+fi
+
+# Validate that the last character is a valid character.
+if [[ "${CHECK_LAST_VALID}" != [a-zA-Z0-9] ]]; then
+    printf "Error: Last character is an invalid character.\n";
+    exit 8;
+fi
+
+# Validate that ${LABEL} is one of the valid labels.
+for validLabel in "${VALID_LABELS[@]}"; do
+    if [ "${LABEL}" == "${validLabel}" ]; then
+        printf "Success: Title's label and description style is valid.\n";
+        exit 0;
+    elif [ "${LABEL}" == "${validLabel}${IGNORE_DECORATOR}" ]; then
+        printf "Success: Title's label and description style is valid with ignore/internal decorator.\n";
+        exit 0;
+    fi
+done
+
+# Should only reach here if the label was invalid.
+printf "Error: The label used in the title isn't a valid label.\n";
+exit 9;


### PR DESCRIPTION
## Relevant issue(s)

Resolves #25

## Description

Adds job to run tests in PRs.  Also adds the Defra PR template, and PR title validation.

Note: Looks like the jobs wont run until after they merge, so testing has been limited.  They are copy-pasted-tweaked from the Lens repo (in turn taken from Defra a while ago).