### PR TITLE
fix: Return correct version iterating mem store in reverse

### DIFF
--- a/memory/iter.go
+++ b/memory/iter.go
@@ -7,210 +7,174 @@ import (
 	"github.com/tidwall/btree"
 )
 
-type dsPrefixIter struct {
-	ctx     context.Context
+type iterator struct {
 	db      *Datastore
 	version uint64
-	it      *baseIterator
-	prefix  []byte
+	it      btree.IterG[dsItem]
+
+	// The key at which this iterator begins.
+	//
+	// This is inclusive only if `mayExactlyMatchStart` is true.
+	start []byte
+
+	// The key at which this iterator ends, inclusive.
+	end []byte
+
+	// If this is true, `start` is inclusive, else `start` is exclusive.
+	mayExactlyMatchStart bool
+
+	// If true, the iterator will iterate in reverse order, from the largest
+	// key to the smallest.
 	reverse bool
-	curItem *dsItem
+
+	// hasItem mutates as the iterator progresses, it will be true
+	// if there are remaining items that can iterated through.
+	hasItem bool
 }
 
-type dsRangeIter struct {
-	ctx     context.Context
-	db      *Datastore
-	version uint64
-	it      *baseIterator
-	start   []byte
-	end     []byte
-	reverse bool
-	curItem *dsItem
-}
+func newPrefixIter(db *Datastore, prefix []byte, reverse bool, version uint64) *iterator {
+	start := prefix
+	end := bytesPrefixEnd(prefix)
 
-func newPrefixIter(ctx context.Context, db *Datastore, prefix []byte, reverse bool, version uint64) *dsPrefixIter {
-	pIter := &dsPrefixIter{
-		ctx:     ctx,
-		db:      db,
-		version: version,
-		it:      newBaseIterator(db.values, reverse, prefix, bytesPrefixEnd(prefix)),
-		prefix:  prefix,
-		reverse: reverse,
-	}
+	it := db.values.Iter()
+	var hasItem bool
 	if reverse {
-		pIter.Seek(bytesPrefixEnd(prefix))
+		hasItem = it.Last()
 	} else {
-		pIter.Seek(prefix)
+		hasItem = it.First()
 	}
 
-	// if the first key is an exact match to the prefix, skip next
-	// since prefix is a *strict* subset prefix
-	if pIter.curItem != nil && bytes.Equal(pIter.Key(), prefix) {
-		pIter.Next()
-	}
-
-	return pIter
-}
-
-func (iter *dsPrefixIter) Domain() (start []byte, end []byte) {
-	return iter.prefix, iter.prefix
-}
-
-func (iter *dsPrefixIter) Valid() bool {
-	return validForPrefix(iter.curItem, iter.prefix)
-}
-
-func validForPrefix(item *dsItem, prefix []byte) bool {
-	if item == nil {
-		return false
-	}
-
-	return bytes.HasPrefix(item.key, prefix) && !bytes.Equal(item.key, prefix)
-}
-
-func (iter *dsPrefixIter) Next() {
-	if iter.it.Next() {
-		iter.loadLatestItem()
-	} else {
-		iter.curItem = nil
-	}
-}
-
-func (iter *dsPrefixIter) Key() []byte {
-	if iter.curItem != nil {
-		return iter.curItem.key
-	}
-	return nil
-}
-
-func (iter *dsPrefixIter) Value() ([]byte, error) {
-	if iter.curItem != nil {
-		return iter.curItem.val, nil
-	}
-	return nil, nil
-}
-
-func (iter *dsPrefixIter) Seek(key []byte) {
-	// get the correct initial version for the seek
-	// if there exists an exact match in keys, use the latest version
-	// of that key, otherwise, use the provided DB version
-	// TODO this could use some "peek" mechanic instead of a full lookup
-	version := iter.version
-	result := iter.db.get(key, version)
-	if result.key != nil && !result.isDeleted {
-		version = result.version
-	}
-
-	if iter.it.Seek(dsItem{key: key, version: version}) {
-		iter.loadLatestItem()
-	} else {
-		iter.curItem = nil
-	}
-}
-
-func (iter *dsPrefixIter) Close(ctx context.Context) error {
-	return iter.it.Close()
-}
-
-func (iter *dsPrefixIter) loadLatestItem() {
-	curItem := iter.it.Item()
-	for iter.it.Next() {
-		if bytes.Equal(curItem.key, iter.it.Item().key) {
-			curItem = iter.it.Item()
-			continue
-		}
-		iter.it.Prev()
-		break
-	}
-
-	if curItem.isDeleted {
-		iter.curItem = nil
-
-		if iter.it.Next() {
-			iter.loadLatestItem()
-		}
-		return
-	}
-
-	if len(curItem.key) == 0 {
-		// If the current item doesn't exist, explicitly set the current item to nil
-		// instead of a default value, this saves us from having to check the length
-		// of the `curItem.key` property everywhere.
-		iter.curItem = nil
-		return
-	}
-
-	iter.curItem = &curItem
-}
-
-type baseIterator struct {
-	it btree.IterG[dsItem]
-
-	// The smallest key that is valid (inclusive bound) for this iterator to return
-	lowerBound []byte
-
-	// The smallest key that is invalid (exclusive bound) for this iterator to return.
-	upperBound []byte
-
-	// If true, this iterator should be yielding items in reverse order.
-	reverse bool
-}
-
-func newRangeIter(ctx context.Context, db *Datastore, start, end []byte, reverse bool, version uint64) *dsRangeIter {
-	rIter := &dsRangeIter{
-		ctx:     ctx,
+	iter := &iterator{
 		db:      db,
 		version: version,
-		it:      newBaseIterator(db.values, reverse, start, end),
+		it:      it,
 		start:   start,
 		end:     end,
-		reverse: reverse,
+		// A prefix iterator should not return a key exactly matching itself.
+		mayExactlyMatchStart: false,
+		reverse:              reverse,
+		hasItem:              hasItem,
+	}
+
+	if reverse {
+		iter.Seek(end)
+	} else {
+		iter.Seek(start)
+	}
+
+	return iter
+}
+
+func newRangeIter(db *Datastore, start, end []byte, reverse bool, version uint64) *iterator {
+	it := db.values.Iter()
+	var hasItem bool
+	if reverse {
+		hasItem = it.Last()
+	} else {
+		hasItem = it.First()
+	}
+
+	iter := &iterator{
+		db:                   db,
+		version:              version,
+		it:                   it,
+		start:                start,
+		end:                  end,
+		mayExactlyMatchStart: true,
+		reverse:              reverse,
+		hasItem:              hasItem,
 	}
 
 	if len(end) > 0 && reverse {
-		rIter.Seek(end)
+		iter.Seek(end)
 	} else if len(start) > 0 && !reverse {
-		rIter.Seek(start)
+		iter.Seek(start)
+	} else if hasItem {
+		iter.loadLatestItem()
+
+		if !iter.Valid() {
+			iter.Next()
+		}
 	}
 
-	rIter.loadLatestItem()
-
-	return rIter
+	return iter
 }
 
-func (iter *dsRangeIter) Domain() (start []byte, end []byte) {
+func (iter *iterator) Domain() (start []byte, end []byte) {
 	return iter.start, iter.end
 }
 
-func (iter *dsRangeIter) Valid() bool {
-	if iter.curItem == nil {
+func (iter *iterator) Valid() bool {
+	if !iter.hasItem {
 		return false
 	}
 
-	if len(iter.end) > 0 && !lt(iter.curItem.key, iter.end) {
+	if iter.it.Item().isDeleted {
 		return false
 	}
 
-	return gte(iter.curItem.key, iter.start)
+	if !iter.mayExactlyMatchStart && (!iter.reverse && bytes.Equal(iter.it.Item().key, iter.start) ||
+		iter.reverse && bytes.Equal(iter.it.Item().key, iter.end)) {
+		return false
+	}
+
+	if len(iter.end) > 0 && !lt(iter.it.Item().key, iter.end) {
+		return false
+	}
+
+	return gte(iter.it.Item().key, iter.start)
 }
 
-func (iter *dsRangeIter) Next() {
-	if iter.it.Next() {
-		iter.loadLatestItem()
-	} else {
-		iter.curItem = nil
+func (iter *iterator) Next() {
+	if !iter.hasItem {
+		return
+	}
+
+	previousItem := iter.it.Item()
+	iter.hasItem = false
+
+	for iter.next() {
+		// Scan through until we reach the next key.
+		// It doesn't matter if it is deleted or not.
+		if !bytes.Equal(previousItem.key, iter.it.Item().key) {
+			iter.hasItem = true
+			break
+		}
+	}
+
+	if !iter.hasItem {
+		return
+	}
+
+	iter.loadLatestItem()
+
+	if iter.it.Item().isDeleted {
+		iter.Next()
 	}
 }
 
-func (iter *dsRangeIter) Key() []byte {
-	return iter.curItem.key
+func (iter *iterator) next() bool {
+	if iter.reverse {
+		// WARNING: There is a bug in `Prev` that can cause unexpected behaviour
+		// when attempting to iterate beyond the end of the iterator.
+		//
+		// This is documented by the test `TestBTreePrevBug`, and our current
+		// interface/implementation should prevent it from surfacing, but be careful
+		// with this call.
+		return iter.it.Prev()
+	}
+	return iter.it.Next()
 }
 
-func (iter *dsRangeIter) Value() ([]byte, error) {
-	return iter.curItem.val, nil
+func (iter *iterator) Key() []byte {
+	return iter.it.Item().key
 }
 
-func (iter *dsRangeIter) Seek(key []byte) {
+func (iter *iterator) Value() ([]byte, error) {
+	return iter.it.Item().val, nil
+}
+
+func (iter *iterator) Seek(key []byte) {
 	// get the correct initial version for the seek
 	// if there exists an exact match in keys, use the latest version
 	// of that key, otherwise, use the provided DB version
@@ -221,122 +185,63 @@ func (iter *dsRangeIter) Seek(key []byte) {
 		version = result.version
 	}
 
-	if iter.it.Seek(dsItem{key: key, version: version}) {
-		iter.loadLatestItem()
-	} else {
-		iter.curItem = nil
-	}
-}
-
-func (iter *dsRangeIter) Close(ctx context.Context) error {
-	return iter.it.Close()
-}
-
-// loadLatestItem gets the latest version of the current key
-func (iter *dsRangeIter) loadLatestItem() {
-	curItem := iter.it.Item()
-	for iter.it.Next() {
-		if bytes.Equal(curItem.key, iter.it.Item().key) {
-			curItem = iter.it.Item()
-			continue
-		}
-		iter.it.Prev()
-		break
-	}
-
-	if curItem.isDeleted {
-		iter.curItem = nil
-
-		if iter.it.Next() {
-			iter.loadLatestItem()
-		}
-		return
-	}
-
-	if len(curItem.key) == 0 {
-		// If the current item doesn't exist, explicitly set the current item to nil
-		// instead of a default value, this saves us from having to check the length
-		// of the `curItem.key` property everywhere.
-		iter.curItem = nil
-		return
-	}
-
-	iter.curItem = &curItem
-}
-
-func newBaseIterator(bt *btree.BTreeG[dsItem], reverse bool, lowerBound []byte, upperBound []byte) *baseIterator {
-	bit := bt.Iter()
-	if reverse {
-		bit.Last()
-	} else {
-		bit.First()
-	}
-
-	return &baseIterator{
-		it:         bit,
-		upperBound: upperBound,
-		lowerBound: lowerBound,
-		reverse:    reverse,
-	}
-}
-
-func (bit *baseIterator) Next() bool {
-	if bit.reverse {
-		return bit.it.Prev()
-	}
-	return bit.it.Next()
-}
-
-func (bit *baseIterator) Prev() bool {
-	if bit.reverse {
-		return bit.it.Next()
-	}
-	return bit.it.Prev()
-}
-
-func (bit *baseIterator) Item() dsItem {
-	return bit.it.Item()
-}
-
-func (bit *baseIterator) Seek(key dsItem) bool {
-	if bit.reverse {
+	if iter.reverse {
 		// Unfortunately the BTree iterator doesn't provide a reversed seek, so we have to
 		// do a bit of work ourselves here if iterating in reverse.
 
-		if bit.upperBound == nil {
+		if iter.end == nil {
 			// If no upper bound has been provided, e.g. via an `End` or `Prefix` option
 			// we can just return the last item in the BTree.
-			return bit.it.Last()
-		}
+			iter.hasItem = iter.it.Last()
+		} else {
+			iter.hasItem = iter.it.Seek(dsItem{key: iter.end, version: version})
+			if iter.hasItem {
+				// If the BTree iterator `Seek` finds an item, it must be equal or greater than
+				// our upper bound.  The previous item key must then be less than our upper bound.
+				iter.hasItem = iter.it.Prev()
+			}
 
-		hasItems := bit.it.Seek(dsItem{key: bit.upperBound, version: key.version})
-		if hasItems {
-			// If the BTree iterator `Seek` finds an item, it must be equal or greater than
-			// our upper bound.  The previous item key must then be less than our upper bound.
-			hasItems = bit.it.Prev()
-		}
+			if !iter.hasItem {
+				// If no items were found above or on the upper bound, we can move to the end of the
+				// BTree.
+				iter.hasItem = iter.it.Last()
+			}
 
-		if !hasItems {
-			// If no items were found above or on the upper bound, we can move to the end of the
-			// BTree.
-			hasItems = bit.it.Last()
+			if !iter.hasItem {
+				// If there are no items found at this point, it means the store is empty.
+				return
+			}
 		}
-
-		if !hasItems {
-			// If there are no items found at this point, it means the store is empty.
-			return false
-		}
-
-		// Only return true if the item is within the lower bound.
-		return bit.lowerBound != nil && gte(bit.it.Item().key, bit.lowerBound)
+	} else {
+		iter.hasItem = iter.it.Seek(dsItem{key: key, version: version})
 	}
 
-	return bit.it.Seek(key)
+	if !iter.hasItem {
+		return
+	}
+
+	iter.loadLatestItem()
+
+	if !iter.Valid() {
+		iter.Next()
+	}
 }
 
-func (bit *baseIterator) Close() error {
-	bit.it.Release()
+func (iter *iterator) Close(ctx context.Context) error {
+	iter.it.Release()
 	return nil
+}
+
+func (iter *iterator) loadLatestItem() {
+	previousItem := iter.it.Item()
+	for iter.it.Next() {
+		// Scan through until we reach the next key.
+		// It doesn't matter if it is deleted or not.
+		if !bytes.Equal(previousItem.key, iter.it.Item().key) {
+			iter.it.Prev()
+			break
+		}
+	}
 }
 
 func bytesPrefixEnd(b []byte) []byte {

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -223,7 +223,16 @@ func (iter *iterator) Seek(key []byte) {
 			return
 		}
 	} else {
-		iter.hasItem = iter.it.Seek(dsItem{key: key, version: version})
+		var target []byte
+		if iter.start != nil && lt(key, iter.start) {
+			// We should not yield keys smaller than `start`, so if the given seek-key
+			// is smaller than `start`, we should instead seek to `start`.
+			target = iter.start
+		} else {
+			target = key
+		}
+
+		iter.hasItem = iter.it.Seek(dsItem{key: target, version: version})
 	}
 
 	if !iter.hasItem {

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -50,7 +50,7 @@ func newPrefixIter(db *Datastore, prefix []byte, reverse bool, version uint64) *
 		it:      it,
 		start:   start,
 		end:     end,
-		// A prefix iterator should not return a key exactly matching itself.
+		// A prefix iterator must not return a key exactly matching itself.
 		isStartInclusive: false,
 		reverse:          reverse,
 		hasItem:          hasItem,

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -21,7 +21,7 @@ type iterator struct {
 	end []byte
 
 	// If this is true, `start` is inclusive, else `start` is exclusive.
-	mayExactlyMatchStart bool
+	isStartInclusive bool
 
 	// If true, the iterator will iterate in reverse order, from the largest
 	// key to the smallest.
@@ -51,9 +51,9 @@ func newPrefixIter(db *Datastore, prefix []byte, reverse bool, version uint64) *
 		start:   start,
 		end:     end,
 		// A prefix iterator should not return a key exactly matching itself.
-		mayExactlyMatchStart: false,
-		reverse:              reverse,
-		hasItem:              hasItem,
+		isStartInclusive: false,
+		reverse:          reverse,
+		hasItem:          hasItem,
 	}
 
 	if reverse {
@@ -75,14 +75,14 @@ func newRangeIter(db *Datastore, start, end []byte, reverse bool, version uint64
 	}
 
 	iter := &iterator{
-		db:                   db,
-		version:              version,
-		it:                   it,
-		start:                start,
-		end:                  end,
-		mayExactlyMatchStart: true,
-		reverse:              reverse,
-		hasItem:              hasItem,
+		db:               db,
+		version:          version,
+		it:               it,
+		start:            start,
+		end:              end,
+		isStartInclusive: true,
+		reverse:          reverse,
+		hasItem:          hasItem,
 	}
 
 	if len(end) > 0 && reverse {
@@ -113,7 +113,7 @@ func (iter *iterator) Valid() bool {
 		return false
 	}
 
-	if !iter.mayExactlyMatchStart && (!iter.reverse && bytes.Equal(iter.it.Item().key, iter.start) ||
+	if !iter.isStartInclusive && (!iter.reverse && bytes.Equal(iter.it.Item().key, iter.start) ||
 		iter.reverse && bytes.Equal(iter.it.Item().key, iter.end)) {
 		return false
 	}

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/sourcenetwork/corekv"
+
 	"github.com/tidwall/btree"
 )
 
@@ -31,6 +33,8 @@ type iterator struct {
 	// if there are remaining items that can iterated through.
 	hasItem bool
 }
+
+var _ corekv.Iterator = (*iterator)(nil)
 
 func newPrefixIter(db *Datastore, prefix []byte, reverse bool, version uint64) *iterator {
 	start := prefix

--- a/memory/iter_test.go
+++ b/memory/iter_test.go
@@ -1,0 +1,85 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/btree"
+)
+
+func comparator(a, b int) bool {
+	return a < b
+}
+
+// This test documents undesirable behaviour of the btree implementation
+// that we are currently using, it is documented by issue:
+// https://github.com/tidwall/btree/issues/46
+//
+// This test exists here to document unexpected behaviour in the hope that
+// it saves time in the future.
+func TestBTreePrevBug(t *testing.T) {
+	tree := btree.NewBTreeG(comparator)
+
+	tree.Set(1)
+	tree.Set(2)
+	tree.Set(3)
+
+	iterator := tree.Iter()
+
+	ok := iterator.Last()
+	require.True(t, ok)
+
+	// The presence of this `Next` call causes the bug to surface later.
+	// If commented out, later `Prev` calls behave as expected.
+	ok = iterator.Next()
+	require.False(t, ok)
+
+	ok = iterator.Prev()
+	require.True(t, ok)
+
+	v := iterator.Item()
+	require.Equal(t, 2, v)
+
+	ok = iterator.Prev()
+	require.True(t, ok)
+
+	v = iterator.Item()
+	require.Equal(t, 1, v)
+
+	ok = iterator.Prev()
+	require.False(t, ok)
+
+	// Bug starts here!
+	//
+	// Notes:
+	// 1. I expected all the `Prev` calls beyond this point to return `false`.
+	// 2. If you comment out the `Next` call noted towards the top of the function,
+	//    the `Prev` calls all return `true` as I expected.
+	// 3. The `Item` calls are included for descriptive reasons only, I found them
+	//    interesting, but much less so than the return value from `Prev`.
+	// 4. The 2, 1, 1; 2, 1, 1; patern repeats as far as I bothered looking at.
+
+	ok = iterator.Prev()
+	require.True(t, ok)
+
+	v = iterator.Item()
+	require.Equal(t, 2, v)
+
+	ok = iterator.Prev()
+	require.True(t, ok)
+
+	v = iterator.Item()
+	require.Equal(t, 1, v)
+
+	ok = iterator.Prev()
+	require.False(t, ok)
+
+	v = iterator.Item()
+	require.Equal(t, 1, v)
+
+	ok = iterator.Prev()
+	require.True(t, ok)
+
+	v = iterator.Item()
+	require.Equal(t, 2, v)
+}

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -240,9 +240,9 @@ func (d *Datastore) Set(ctx context.Context, key []byte, value []byte) (err erro
 
 func (d *Datastore) Iterator(ctx context.Context, opts corekv.IterOptions) corekv.Iterator {
 	if opts.Prefix != nil {
-		return newPrefixIter(ctx, d, opts.Prefix, opts.Reverse, d.getVersion())
+		return newPrefixIter(d, opts.Prefix, opts.Reverse, d.getVersion())
 	}
-	return newRangeIter(ctx, d, opts.Start, opts.End, opts.Reverse, d.getVersion())
+	return newRangeIter(d, opts.Start, opts.End, opts.Reverse, d.getVersion())
 }
 
 // purgeOldVersions will execute the purge once a day or when explicitly requested.

--- a/test/action/iterator.go
+++ b/test/action/iterator.go
@@ -97,3 +97,27 @@ func Next() *MoveNext {
 func (a *MoveNext) Execute(s *state.State, iterator corekv.Iterator) {
 	iterator.Next()
 }
+
+// Valid executes a single `Value` call on an [Iterator] and requires that
+// the returned result matches the given `Expected` value.
+type IteratorValue struct {
+	// The expected result of the `Value` call.
+	Expected []byte
+}
+
+var _ IteratorAction = (*IteratorValue)(nil)
+
+// Value returns a [IteratorValue] iterator action that executes a single `Value` call
+// on an [Iterator] and requires that the returned result equals the given expected value.
+func Value(expected []byte) *IteratorValue {
+	return &IteratorValue{
+		Expected: expected,
+	}
+}
+
+func (a *IteratorValue) Execute(s *state.State, iterator corekv.Iterator) {
+	actual, err := iterator.Value()
+	require.NoError(s.T, err)
+
+	require.Equal(s.T, a.Expected, actual)
+}

--- a/test/integration/iterator/prefix_set_test.go
+++ b/test/integration/iterator/prefix_set_test.go
@@ -1,0 +1,28 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorPrefixSet(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k1"), []byte("v1.1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1.1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/prefix_test.go
+++ b/test/integration/iterator/prefix_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
 )
 
 func TestIteratorPrefix(t *testing.T) {
@@ -24,6 +25,55 @@ func TestIteratorPrefix(t *testing.T) {
 					{Key: []byte("k2"), Value: []byte("v2")},
 					{Key: []byte("k3"), Value: nil},
 					// `4` must not be yielded
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorPrefix_DoesNotReturnSelf_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k"), []byte("v")),
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					// `k` must not be yielded, as prefxes do not contain themselves
+					{Key: []byte("k1"), Value: []byte("v1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents unwanted behaviour, it is tracked by:
+// https://github.com/sourcenetwork/corekv/issues/27
+func TestIteratorPrefix_DoesNotReturnSelf_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k"), []byte("v")),
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					// `k` should not be yielded, but it is.
+					{Key: []byte("k"), Value: []byte("v")},
+					{Key: []byte("k1"), Value: []byte("v1")},
 				},
 			},
 		},

--- a/test/integration/iterator/reverse_end_seek_valid_value_test.go
+++ b/test/integration/iterator/reverse_end_seek_valid_value_test.go
@@ -39,3 +39,30 @@ func TestIteratorReverseEndSeekValidValue_Badger(t *testing.T) {
 
 	test.Execute(t)
 }
+
+func TestIteratorReverseEndSeekValidValue_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					End:     []byte("k3"),
+				},
+				ChildActions: []action.IteratorAction{
+					action.Seek([]byte("k4")),
+					action.IsValid(),
+					action.Value([]byte("v2")),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_end_seek_valid_value_test.go
+++ b/test/integration/iterator/reverse_end_seek_valid_value_test.go
@@ -1,0 +1,41 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+// This test documents unwanted behaviour tracked by issue:
+// https://github.com/sourcenetwork/corekv/issues/38
+func TestIteratorReverseEndSeekValidValue_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					End:     []byte("k3"),
+				},
+				ChildActions: []action.IteratorAction{
+					action.Seek([]byte("k4")),
+					action.IsValid(),
+					// `k4` is outside of the upper bound of the iterator and
+					// should not be returned, but it is.
+					action.Value([]byte("v4")),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_end_valid_test.go
+++ b/test/integration/iterator/reverse_end_valid_test.go
@@ -6,15 +6,10 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
 func TestIteratorReverseEndValid(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
-		Namespacing: integration.ManualOnly,
 		Actions: []action.Action{
 			&action.Iterator{
 				IterOptions: corekv.IterOptions{

--- a/test/integration/iterator/reverse_next_valid_test.go
+++ b/test/integration/iterator/reverse_next_valid_test.go
@@ -49,7 +49,7 @@ func TestIteratorReverseNextValid_Badger(t *testing.T) {
 	)
 }
 
-func TestIteratorReverseNextValid_MemoryUnnamespaced(t *testing.T) {
+func TestIteratorReverseNextValid_Memory(t *testing.T) {
 	test := &integration.Test{
 		SupportedStoreTypes: []state.StoreType{
 			state.MemoryStoreType,

--- a/test/integration/iterator/reverse_prefix_set_test.go
+++ b/test/integration/iterator/reverse_prefix_set_test.go
@@ -1,0 +1,61 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorReversePrefixSet_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k1"), []byte("v1.1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Prefix:  []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1.1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents unwanted behaviour, it will be removed in a later commit.
+/*
+It is commented out because it currently enters an infinate loop. Due to the loop
+the would-be behviour is a guess.
+func TestIteratorReversePrefixSet_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k1"), []byte("v1.1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+					Prefix:  []byte("k"),
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+*/

--- a/test/integration/iterator/reverse_prefix_set_test.go
+++ b/test/integration/iterator/reverse_prefix_set_test.go
@@ -6,14 +6,10 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
-func TestIteratorReversePrefixSet_Badger(t *testing.T) {
+func TestIteratorReversePrefixSet(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k1"), []byte("v1.1")),
@@ -31,31 +27,3 @@ func TestIteratorReversePrefixSet_Badger(t *testing.T) {
 
 	test.Execute(t)
 }
-
-// This test documents unwanted behaviour, it will be removed in a later commit.
-/*
-It is commented out because it currently enters an infinate loop. Due to the loop
-the would-be behviour is a guess.
-func TestIteratorReversePrefixSet_Memory(t *testing.T) {
-	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
-		Actions: []action.Action{
-			action.Set([]byte("k1"), []byte("v1")),
-			action.Set([]byte("k1"), []byte("v1.1")),
-			&action.Iterate{
-				IterOptions: corekv.IterOptions{
-					Reverse: true,
-					Prefix:  []byte("k"),
-				},
-				Expected: []action.KeyValue{
-					{Key: []byte("k1"), Value: []byte("v1")},
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}
-*/

--- a/test/integration/iterator/reverse_seek_valid_value_test.go
+++ b/test/integration/iterator/reverse_seek_valid_value_test.go
@@ -1,0 +1,37 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorReverseSeekValidValue(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Namespacing: integration.ManualOnly,
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				ChildActions: []action.IteratorAction{
+					action.Seek([]byte("k2")),
+					action.IsValid(),
+					action.Value([]byte("v2")),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_set_test.go
+++ b/test/integration/iterator/reverse_set_test.go
@@ -1,0 +1,55 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+func TestIteratorReverseSet_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k1"), []byte("v1.1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1.1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+// This test documents unwanted behaviour, it will be removed in a later commit.
+func TestIteratorReverseSet_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k1"), []byte("v1.1")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k1"), Value: []byte("v1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/reverse_set_test.go
+++ b/test/integration/iterator/reverse_set_test.go
@@ -6,14 +6,10 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
-func TestIteratorReverseSet_Badger(t *testing.T) {
+func TestIteratorReverseSet(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k1"), []byte("v1.1")),
@@ -23,29 +19,6 @@ func TestIteratorReverseSet_Badger(t *testing.T) {
 				},
 				Expected: []action.KeyValue{
 					{Key: []byte("k1"), Value: []byte("v1.1")},
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}
-
-// This test documents unwanted behaviour, it will be removed in a later commit.
-func TestIteratorReverseSet_Memory(t *testing.T) {
-	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
-		Actions: []action.Action{
-			action.Set([]byte("k1"), []byte("v1")),
-			action.Set([]byte("k1"), []byte("v1.1")),
-			&action.Iterate{
-				IterOptions: corekv.IterOptions{
-					Reverse: true,
-				},
-				Expected: []action.KeyValue{
-					{Key: []byte("k1"), Value: []byte("v1")},
 				},
 			},
 		},

--- a/test/integration/iterator/reverse_test.go
+++ b/test/integration/iterator/reverse_test.go
@@ -6,15 +6,10 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
 func TestIteratorReverse(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
-		Namespacing: integration.AutomaticForced,
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), nil),

--- a/test/integration/iterator/start_seek_valid_value_test.go
+++ b/test/integration/iterator/start_seek_valid_value_test.go
@@ -1,0 +1,66 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/state"
+)
+
+// This test documents unwanted behaviour tracked by issue:
+// https://github.com/sourcenetwork/corekv/issues/38
+func TestIteratorStartSeekValidValue_Badger(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.BadgerStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Start: []byte("k3"),
+				},
+				ChildActions: []action.IteratorAction{
+					action.Seek([]byte("k1")),
+					action.IsValid(),
+					// `k1` is outside of the upper bound of the iterator and
+					// should not be returned, but it is.
+					action.Value([]byte("v1")),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratortartSeekValidValue_Memory(t *testing.T) {
+	test := &integration.Test{
+		SupportedStoreTypes: []state.StoreType{
+			state.MemoryStoreType,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), nil),
+			action.Set([]byte("k4"), []byte("v4")),
+			action.Set([]byte("k2"), []byte("v2")),
+			&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Start: []byte("k3"),
+				},
+				ChildActions: []action.IteratorAction{
+					action.Seek([]byte("k1")),
+					action.IsValid(),
+					action.Value(nil),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #22

## Description

Returns the correct value-version when iterating through the memory store in reverse.

Also documents a newly discovered badger iterator bug, and a bug in the btree implementation.

The memory store iterator has been restructured somewhat in this PR, consider reviewing the whole iter.go file as if it were new, I'm happy to bring into scope any suggestions for unchanged lines here.
