### PR TITLE
refactor: Remove namespace store mutex

### DIFF
--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -91,7 +91,7 @@ func strip(prefix, key []byte) []byte {
 
 // Iterator creates a new iterator instance
 func (nstore *namespaceStore) Iterator(ctx context.Context, opts corekv.IterOptions) corekv.Iterator {
-	// make a copy the namespace so that we can safely mutate it within this function
+	// make a copy of the namespace so that we can safely mutate it within this function
 	namespace := cp(nstore.namespace)
 
 	var hasStart bool


### PR DESCRIPTION
## Relevant issue(s)

Resolves #24

## Description

Removes the namespace store mutex.

They are never write locked, there is nothing in the namespace store that needs locking, the underlying stores do their own locking, and the current interfaces do not currently facilitate any fancy namespace based locking that could be done - if we want to make an optimisation in the future it will take a fair bit more effort as we'll need to bypass any locks managed by the underlying stores.
