### PR TITLE
fix: Remove Iterator.Domain

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -232,10 +232,6 @@ type rangeIterator struct {
 	closer   func() error
 }
 
-func (it *rangeIterator) Domain() (start []byte, end []byte) {
-	return it.start, it.end
-}
-
 func (it *rangeIterator) Valid() bool {
 	if !it.i.Valid() {
 		return false
@@ -290,10 +286,6 @@ type prefixIterator struct {
 	reverse  bool
 	keysOnly bool
 	closer   func() error
-}
-
-func (it *prefixIterator) Domain() (start []byte, end []byte) {
-	return it.prefix, it.prefix
 }
 
 func (it *prefixIterator) Valid() bool {

--- a/kv.go
+++ b/kv.go
@@ -90,11 +90,6 @@ type Writer interface {
 // Iterator is a read-only iterator that allows iteration over the underlying
 // store (or a part of it).
 type Iterator interface {
-	// The behaviour of Domain is undefined and varies heavily depending on
-	// which store implementation is being iterated over:
-	// https://github.com/sourcenetwork/corekv/issues/31
-	Domain() (start []byte, end []byte)
-
 	// Valid returns true if the iterator can return a valid item from
 	// `Value`.
 	//

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -104,10 +104,6 @@ func newRangeIter(db *Datastore, start, end []byte, reverse bool, version uint64
 	return iter
 }
 
-func (iter *iterator) Domain() (start []byte, end []byte) {
-	return iter.start, iter.end
-}
-
 func (iter *iterator) Valid() bool {
 	if !iter.hasItem {
 		return false

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -82,13 +82,6 @@ func prefixed(prefix, key []byte) []byte {
 	return append(cp(prefix), key...)
 }
 
-func strip(prefix, key []byte) []byte {
-	if len(key) >= len(prefix) {
-		return key[len(prefix):]
-	}
-	return key
-}
-
 // Iterator creates a new iterator instance
 func (nstore *namespaceStore) Iterator(ctx context.Context, opts corekv.IterOptions) corekv.Iterator {
 	// make a copy of the namespace so that we can safely mutate it within this function
@@ -159,19 +152,6 @@ type namespaceIterator struct {
 	hasStart  bool // original IterOpts.Start
 	hasEnd    bool // original IterOpts.End
 	it        corekv.Iterator
-}
-
-// todo: Should the domain contain the namespace, or strip it?
-func (nIter *namespaceIterator) Domain() (start []byte, end []byte) {
-	start, end = nIter.it.Domain()
-	if start != nil {
-		start = strip(nIter.namespace, start)
-	}
-	if end != nil {
-		end = strip(nIter.namespace, end)
-	}
-
-	return start, end
 }
 
 func (nIter *namespaceIterator) Valid() bool {


### PR DESCRIPTION
## Relevant issue(s)

Resolves #42 

## Description

Removes the Iterator.Domain function.

As discussed in https://github.com/sourcenetwork/corekv/pull/40 - as the implementing behaviour varied quite a bit and it didn't fully make sense.