### PR TITLE
fix: Limit badger iterator seek to iterator bounds

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -139,9 +139,9 @@ func (txn *bTxn) Iterator(ctx context.Context, iterOpts corekv.IterOptions) core
 
 func (txn *bTxn) iterator(iopts corekv.IterOptions) iteratorCloser {
 	if iopts.Prefix != nil {
-		return txn.prefixIterator(iopts.Prefix, iopts.Reverse, iopts.KeysOnly)
+		return newPrefixIterator(txn, iopts.Prefix, iopts.Reverse, iopts.KeysOnly)
 	}
-	return txn.rangeIterator(iopts.Start, iopts.End, iopts.Reverse, iopts.KeysOnly)
+	return newRangeIterator(txn, iopts.Start, iopts.End, iopts.Reverse, iopts.KeysOnly)
 }
 
 func (txn *bTxn) Set(ctx context.Context, key []byte, value []byte) error {

--- a/badger/badger.go
+++ b/badger/badger.go
@@ -1,7 +1,6 @@
 package badger
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -145,36 +144,6 @@ func (txn *bTxn) iterator(iopts corekv.IterOptions) iteratorCloser {
 	return txn.rangeIterator(iopts.Start, iopts.End, iopts.Reverse, iopts.KeysOnly)
 }
 
-func (txn *bTxn) prefixIterator(prefix []byte, reverse, keysOnly bool) *prefixIterator {
-	opt := badger.DefaultIteratorOptions
-	opt.Reverse = reverse
-	opt.Prefix = prefix
-	opt.PrefetchValues = !keysOnly
-
-	return &prefixIterator{
-		i:        txn.t.NewIterator(opt),
-		prefix:   prefix,
-		reverse:  reverse,
-		keysOnly: keysOnly,
-		reset:    true,
-	}
-}
-
-func (txn *bTxn) rangeIterator(start, end []byte, reverse, keysOnky bool) *rangeIterator {
-	opt := badger.DefaultIteratorOptions
-	opt.Reverse = reverse
-	opt.PrefetchValues = !keysOnky
-
-	return &rangeIterator{
-		i:        txn.t.NewIterator(opt),
-		start:    start,
-		end:      end,
-		reverse:  reverse,
-		keysOnly: keysOnky,
-		reset:    true,
-	}
-}
-
 func (txn *bTxn) Set(ctx context.Context, key []byte, value []byte) error {
 	err := txn.t.Set(key, value)
 	return badgerErrToKVErr(err)
@@ -193,189 +162,6 @@ func (txn *bTxn) Commit(ctx context.Context) error {
 func (txn *bTxn) Discard(ctx context.Context) error {
 	txn.t.Discard()
 	return nil
-}
-
-type iteratorCloser interface {
-	corekv.Iterator
-	withCloser(func() error)
-}
-
-type rangeIterator struct {
-	i        *badger.Iterator
-	start    []byte
-	end      []byte
-	reverse  bool
-	keysOnly bool
-	// reset is a mutatuble property that indicates whether the iterator should be
-	// returned to the beginning on the next [Next] call.
-	reset  bool
-	closer func() error
-}
-
-func (it *rangeIterator) Reset() {
-	it.reset = true
-}
-
-// restart returns the iterator back to it's initial location at time of construction,
-// allowing re-iteration of the underlying data.
-func (it *rangeIterator) restart() (bool, error) {
-	it.reset = false
-
-	if it.reverse {
-		hasValue, err := it.Seek(it.end)
-		if !hasValue || err != nil {
-			return false, err
-		}
-
-		// if we seeked to the end and its an exact match to the end marker
-		// go next. This is because ranges are [start, end) (exlusive)
-		//
-		// todo: This check is in the wrong place and is a symptom of:
-		// https://github.com/sourcenetwork/corekv/issues/38 - this check
-		// needs to move to `valid` once/as `Seek` is being fixed.
-		if equal(it.i.Item().Key(), it.end) {
-			return it.Next()
-		}
-
-		return true, nil
-	} else {
-		return it.Seek(it.start)
-	}
-}
-
-func (it *rangeIterator) valid() bool {
-	if !it.i.Valid() {
-		return false
-	}
-
-	// if its reversed, we check if we passed the start key
-	if it.reverse && it.start != nil {
-		return bytes.Compare(it.i.Item().Key(), it.start) >= 0 // inclusive
-	} else if !it.reverse && it.end != nil {
-		// if its forward, we check if we passed the end key
-		return bytes.Compare(it.i.Item().Key(), it.end) < 0 // exlusive
-	}
-
-	return true
-}
-
-func (it *rangeIterator) Next() (bool, error) {
-	if it.reset {
-		return it.restart()
-	}
-
-	it.i.Next()
-	return it.valid(), nil
-}
-
-func (it *rangeIterator) Key() []byte {
-	return it.i.Item().KeyCopy(nil)
-}
-
-func (it *rangeIterator) Value() ([]byte, error) {
-	if it.keysOnly {
-		return nil, nil
-	}
-
-	return it.i.Item().ValueCopy(nil)
-}
-
-func (it *rangeIterator) Seek(target []byte) (bool, error) {
-	// Clear the reset property, else if Next was call following Seek,
-	// Next may incorrectly return to the beginning.
-	it.reset = false
-
-	it.i.Seek(target)
-	return it.valid(), nil
-}
-
-func (it *rangeIterator) Close(ctx context.Context) error {
-	it.i.Close()
-	if it.closer != nil {
-		return it.closer()
-	}
-	return nil
-}
-
-func (it *rangeIterator) withCloser(closer func() error) {
-	it.closer = closer
-}
-
-type prefixIterator struct {
-	i        *badger.Iterator
-	prefix   []byte
-	reverse  bool
-	keysOnly bool
-	// reset is a mutatuble property that indicates whether the iterator should be
-	// returned to the beginning on the next [Next] call.
-	reset  bool
-	closer func() error
-}
-
-func (it *prefixIterator) Reset() {
-	it.reset = true
-}
-
-// restart returns the iterator back to it's initial location at time of construction,
-// allowing re-iteration of the underlying data.
-func (it *prefixIterator) restart() (bool, error) {
-	it.reset = false
-
-	if it.reverse {
-		hasItem, err := it.Seek(bytesPrefixEnd(it.prefix))
-		if !hasItem || err != nil {
-			return false, err
-		}
-
-		if !it.i.ValidForPrefix(it.prefix) {
-			return it.Next()
-		}
-
-		return true, nil
-	} else {
-		return it.Seek(it.prefix)
-	}
-}
-
-func (it *prefixIterator) Next() (bool, error) {
-	if it.reset {
-		return it.restart()
-	}
-
-	it.i.Next()
-	return it.i.ValidForPrefix(it.prefix), nil
-}
-
-func (it *prefixIterator) Key() []byte {
-	return it.i.Item().KeyCopy(nil)
-}
-
-func (it *prefixIterator) Value() ([]byte, error) {
-	if it.keysOnly {
-		return nil, nil
-	}
-	return it.i.Item().ValueCopy(nil)
-}
-
-func (it *prefixIterator) Seek(target []byte) (bool, error) {
-	// Clear the reset property, else if Next was call following Seek,
-	// Next may incorrectly return to the beginning.
-	it.reset = false
-
-	it.i.Seek(target)
-	return it.i.ValidForPrefix(it.prefix), nil
-}
-
-func (it *prefixIterator) Close(ctx context.Context) error {
-	it.i.Close()
-	if it.closer != nil {
-		return it.closer()
-	}
-	return nil
-}
-
-func (it *prefixIterator) withCloser(closer func() error) {
-	it.closer = closer
 }
 
 var badgerErrToKVErrMap = map[error]error{
@@ -414,22 +200,4 @@ func badgerErrToKVErr(err error) error {
 
 	return errors.Join(mappedErr, err)
 
-}
-
-func equal(a, b []byte) bool {
-	return bytes.Equal(a, b)
-}
-
-func bytesPrefixEnd(b []byte) []byte {
-	end := make([]byte, len(b))
-	copy(end, b)
-	for i := len(end) - 1; i >= 0; i-- {
-		end[i] = end[i] + 1
-		if end[i] != 0 {
-			return end[:i+1]
-		}
-	}
-	// This statement will only be reached if the key is already a
-	// maximal byte string (i.e. already \xff...).
-	return b
 }

--- a/badger/iter.go
+++ b/badger/iter.go
@@ -1,0 +1,241 @@
+package badger
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/dgraph-io/badger/v4"
+
+	"github.com/sourcenetwork/corekv"
+)
+
+type iteratorCloser interface {
+	corekv.Iterator
+	withCloser(func() error)
+}
+
+type rangeIterator struct {
+	i        *badger.Iterator
+	start    []byte
+	end      []byte
+	reverse  bool
+	keysOnly bool
+	// reset is a mutatuble property that indicates whether the iterator should be
+	// returned to the beginning on the next [Next] call.
+	reset  bool
+	closer func() error
+}
+
+type prefixIterator struct {
+	i        *badger.Iterator
+	prefix   []byte
+	reverse  bool
+	keysOnly bool
+	// reset is a mutatuble property that indicates whether the iterator should be
+	// returned to the beginning on the next [Next] call.
+	reset  bool
+	closer func() error
+}
+
+func (txn *bTxn) prefixIterator(prefix []byte, reverse, keysOnly bool) *prefixIterator {
+	opt := badger.DefaultIteratorOptions
+	opt.Reverse = reverse
+	opt.Prefix = prefix
+	opt.PrefetchValues = !keysOnly
+
+	return &prefixIterator{
+		i:        txn.t.NewIterator(opt),
+		prefix:   prefix,
+		reverse:  reverse,
+		keysOnly: keysOnly,
+		reset:    true,
+	}
+}
+
+func (txn *bTxn) rangeIterator(start, end []byte, reverse, keysOnky bool) *rangeIterator {
+	opt := badger.DefaultIteratorOptions
+	opt.Reverse = reverse
+	opt.PrefetchValues = !keysOnky
+
+	return &rangeIterator{
+		i:        txn.t.NewIterator(opt),
+		start:    start,
+		end:      end,
+		reverse:  reverse,
+		keysOnly: keysOnky,
+		reset:    true,
+	}
+}
+
+func (it *rangeIterator) Reset() {
+	it.reset = true
+}
+
+// restart returns the iterator back to it's initial location at time of construction,
+// allowing re-iteration of the underlying data.
+func (it *rangeIterator) restart() (bool, error) {
+	it.reset = false
+
+	if it.reverse {
+		hasValue, err := it.Seek(it.end)
+		if !hasValue || err != nil {
+			return false, err
+		}
+
+		// if we seeked to the end and its an exact match to the end marker
+		// go next. This is because ranges are [start, end) (exlusive)
+		//
+		// todo: This check is in the wrong place and is a symptom of:
+		// https://github.com/sourcenetwork/corekv/issues/38 - this check
+		// needs to move to `valid` once/as `Seek` is being fixed.
+		if equal(it.i.Item().Key(), it.end) {
+			return it.Next()
+		}
+
+		return true, nil
+	} else {
+		return it.Seek(it.start)
+	}
+}
+
+func (it *rangeIterator) valid() bool {
+	if !it.i.Valid() {
+		return false
+	}
+
+	// if its reversed, we check if we passed the start key
+	if it.reverse && it.start != nil {
+		return bytes.Compare(it.i.Item().Key(), it.start) >= 0 // inclusive
+	} else if !it.reverse && it.end != nil {
+		// if its forward, we check if we passed the end key
+		return bytes.Compare(it.i.Item().Key(), it.end) < 0 // exlusive
+	}
+
+	return true
+}
+
+func (it *rangeIterator) Next() (bool, error) {
+	if it.reset {
+		return it.restart()
+	}
+
+	it.i.Next()
+	return it.valid(), nil
+}
+
+func (it *rangeIterator) Key() []byte {
+	return it.i.Item().KeyCopy(nil)
+}
+
+func (it *rangeIterator) Value() ([]byte, error) {
+	if it.keysOnly {
+		return nil, nil
+	}
+
+	return it.i.Item().ValueCopy(nil)
+}
+
+func (it *rangeIterator) Seek(target []byte) (bool, error) {
+	// Clear the reset property, else if Next was call following Seek,
+	// Next may incorrectly return to the beginning.
+	it.reset = false
+
+	it.i.Seek(target)
+	return it.valid(), nil
+}
+
+func (it *rangeIterator) Close(ctx context.Context) error {
+	it.i.Close()
+	if it.closer != nil {
+		return it.closer()
+	}
+	return nil
+}
+
+func (it *rangeIterator) withCloser(closer func() error) {
+	it.closer = closer
+}
+
+func (it *prefixIterator) Reset() {
+	it.reset = true
+}
+
+// restart returns the iterator back to it's initial location at time of construction,
+// allowing re-iteration of the underlying data.
+func (it *prefixIterator) restart() (bool, error) {
+	it.reset = false
+
+	if it.reverse {
+		hasItem, err := it.Seek(bytesPrefixEnd(it.prefix))
+		if !hasItem || err != nil {
+			return false, err
+		}
+
+		if !it.i.ValidForPrefix(it.prefix) {
+			return it.Next()
+		}
+
+		return true, nil
+	} else {
+		return it.Seek(it.prefix)
+	}
+}
+
+func (it *prefixIterator) Next() (bool, error) {
+	if it.reset {
+		return it.restart()
+	}
+
+	it.i.Next()
+	return it.i.ValidForPrefix(it.prefix), nil
+}
+
+func (it *prefixIterator) Key() []byte {
+	return it.i.Item().KeyCopy(nil)
+}
+
+func (it *prefixIterator) Value() ([]byte, error) {
+	if it.keysOnly {
+		return nil, nil
+	}
+	return it.i.Item().ValueCopy(nil)
+}
+
+func (it *prefixIterator) Seek(target []byte) (bool, error) {
+	// Clear the reset property, else if Next was call following Seek,
+	// Next may incorrectly return to the beginning.
+	it.reset = false
+
+	it.i.Seek(target)
+	return it.i.ValidForPrefix(it.prefix), nil
+}
+
+func (it *prefixIterator) Close(ctx context.Context) error {
+	it.i.Close()
+	if it.closer != nil {
+		return it.closer()
+	}
+	return nil
+}
+
+func (it *prefixIterator) withCloser(closer func() error) {
+	it.closer = closer
+}
+
+func equal(a, b []byte) bool {
+	return bytes.Equal(a, b)
+}
+
+func bytesPrefixEnd(b []byte) []byte {
+	end := make([]byte, len(b))
+	copy(end, b)
+	for i := len(end) - 1; i >= 0; i-- {
+		end[i] = end[i] + 1
+		if end[i] != 0 {
+			return end[:i+1]
+		}
+	}
+	// This statement will only be reached if the key is already a
+	// maximal byte string (i.e. already \xff...).
+	return b
+}

--- a/badger/iter.go
+++ b/badger/iter.go
@@ -96,7 +96,7 @@ func (it *iterator) Next() (bool, error) {
 
 	if !it.i.Valid() {
 		// `it.i.Next()` will panic if we attempt to call it having already reached
-		// the iterator end, so we much return before trying to make that call if we can.
+		// the iterator end, so we must return before trying to make that call if we can.
 		return false, nil
 	}
 

--- a/badger/iter.go
+++ b/badger/iter.go
@@ -109,6 +109,12 @@ func (it *iterator) Next() (bool, error) {
 		return it.restart()
 	}
 
+	if !it.i.Valid() {
+		// `it.i.Next()` will panic if we attempt to call it having already reached
+		// the iterator end, so we much return before trying to make that call if we can.
+		return false, nil
+	}
+
 	it.i.Next()
 	return it.valid(), nil
 }

--- a/kv.go
+++ b/kv.go
@@ -114,9 +114,7 @@ type Iterator interface {
 	//
 	// Seek will return `true` if it found a valid item, otherwise `false`.
 	//
-	// Seek will not seek to values outside of the constraints provided in [IterOptions],
-	// unless using the badger store due to bug:
-	// https://github.com/sourcenetwork/corekv/issues/38
+	// Seek will not seek to values outside of the constraints provided in [IterOptions].
 	Seek([]byte) (bool, error)
 
 	// Reset resets the iterator, allowing for re-iteration.

--- a/test/integration/iterator/reverse_end_seek_value_test.go
+++ b/test/integration/iterator/reverse_end_seek_value_test.go
@@ -6,44 +6,10 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
-// This test documents unwanted behaviour tracked by issue:
-// https://github.com/sourcenetwork/corekv/issues/38
-func TestIteratorReverseEndSeekValue_Badger(t *testing.T) {
+func TestIteratorReverseEndSeekValue(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
-		Actions: []action.Action{
-			action.Set([]byte("k1"), []byte("v1")),
-			action.Set([]byte("k3"), nil),
-			action.Set([]byte("k4"), []byte("v4")),
-			action.Set([]byte("k2"), []byte("v2")),
-			&action.Iterator{
-				IterOptions: corekv.IterOptions{
-					Reverse: true,
-					End:     []byte("k3"),
-				},
-				ChildActions: []action.IteratorAction{
-					action.Seek([]byte("k4"), true),
-					// `k4` is outside of the upper bound of the iterator and
-					// should not be returned, but it is.
-					action.Value([]byte("v4")),
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}
-
-func TestIteratorReverseEndSeekValue_Memory(t *testing.T) {
-	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), nil),

--- a/test/integration/iterator/reverse_next_test.go
+++ b/test/integration/iterator/reverse_next_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIteratorReverseNext(t *testing.T) {
@@ -28,48 +26,8 @@ func TestIteratorReverseNext(t *testing.T) {
 	test.Execute(t)
 }
 
-// This test documents undesirable behaviour, issue:
-// https://github.com/sourcenetwork/corekv/issues/19
-func TestIteratorReverseNext_BeyondEnd_Badger(t *testing.T) {
+func TestIteratorReverseNext_BeyondEnd(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
-		Actions: []action.Action{
-			action.Set([]byte("k1"), []byte("v1")),
-			action.Set([]byte("k3"), nil),
-			action.Set([]byte("k4"), []byte("v4")),
-			action.Set([]byte("k2"), []byte("v2")),
-			&action.Iterator{
-				IterOptions: corekv.IterOptions{
-					Reverse: true,
-				},
-				ChildActions: []action.IteratorAction{
-					action.Next(true),
-					action.Next(true),
-					action.Next(true),
-					action.Next(true),
-					action.Next(false),
-					action.Next(false),
-				},
-			},
-		},
-	}
-
-	require.PanicsWithError(
-		t,
-		"runtime error: invalid memory address or nil pointer dereference",
-		func() {
-			test.Execute(t)
-		},
-	)
-}
-
-func TestIteratorReverseNext_BeyondEnd_Memory(t *testing.T) {
-	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), nil),

--- a/test/integration/iterator/start_seek_value_test.go
+++ b/test/integration/iterator/start_seek_value_test.go
@@ -6,43 +6,10 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
-// This test documents unwanted behaviour tracked by issue:
-// https://github.com/sourcenetwork/corekv/issues/38
-func TestIteratorStartSeekValue_Badger(t *testing.T) {
+func TestIteratortartSeekValue(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
-		Actions: []action.Action{
-			action.Set([]byte("k1"), []byte("v1")),
-			action.Set([]byte("k3"), nil),
-			action.Set([]byte("k4"), []byte("v4")),
-			action.Set([]byte("k2"), []byte("v2")),
-			&action.Iterator{
-				IterOptions: corekv.IterOptions{
-					Start: []byte("k3"),
-				},
-				ChildActions: []action.IteratorAction{
-					action.Seek([]byte("k1"), true),
-					// `k1` is outside of the upper bound of the iterator and
-					// should not be returned, but it is.
-					action.Value([]byte("v1")),
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}
-
-func TestIteratortartSeekValue_Memory(t *testing.T) {
-	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), nil),


### PR DESCRIPTION
## Relevant issue(s)

Resolves #38
Resolves #19

## Description

Limit badger iterator seek to iterator bounds.

Also fixes a panic when calling badger.Next, and simplifies the badger iterator code. 
