### PR TITLE
fix: Return exact prefix match from memory iterator

### DIFF
--- a/memory/iter.go
+++ b/memory/iter.go
@@ -22,9 +22,6 @@ type iterator struct {
 	// The key at which this iterator ends, inclusive.
 	end []byte
 
-	// If this is true, `start` is inclusive, else `start` is exclusive.
-	isStartInclusive bool
-
 	// If true, the iterator will iterate in reverse order, from the largest
 	// key to the smallest.
 	reverse bool
@@ -43,23 +40,20 @@ func newPrefixIter(db *Datastore, prefix []byte, reverse bool, version uint64) *
 		it:      db.values.Iter(),
 		start:   prefix,
 		end:     bytesPrefixEnd(prefix),
-		// A prefix iterator must not return a key exactly matching itself.
-		isStartInclusive: false,
-		reverse:          reverse,
-		reset:            true,
+		reverse: reverse,
+		reset:   true,
 	}
 }
 
 func newRangeIter(db *Datastore, start, end []byte, reverse bool, version uint64) *iterator {
 	return &iterator{
-		db:               db,
-		version:          version,
-		it:               db.values.Iter(),
-		start:            start,
-		end:              end,
-		isStartInclusive: true,
-		reverse:          reverse,
-		reset:            true,
+		db:      db,
+		version: version,
+		it:      db.values.Iter(),
+		start:   start,
+		end:     end,
+		reverse: reverse,
+		reset:   true,
 	}
 }
 
@@ -106,11 +100,6 @@ func (iter *iterator) valid() bool {
 	}
 
 	if iter.it.Item().isDeleted {
-		return false
-	}
-
-	if !iter.isStartInclusive && (!iter.reverse && bytes.Equal(iter.it.Item().key, iter.start) ||
-		iter.reverse && bytes.Equal(iter.it.Item().key, iter.end)) {
 		return false
 	}
 

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -1,7 +1,6 @@
 package namespace
 
 import (
-	"bytes"
 	"context"
 
 	"github.com/sourcenetwork/corekv"
@@ -108,19 +107,6 @@ type namespaceIterator struct {
 
 func (nIter *namespaceIterator) Reset() {
 	nIter.it.Reset()
-}
-
-func (nIter *namespaceIterator) Valid() bool {
-	// make sure our keys contain the namespace BUT NOT exactly matching
-	key := nIter.it.Key()
-	if bytes.Equal(key, nIter.namespace) {
-		return false
-	}
-	if len(key) >= len(nIter.namespace) && !bytes.Equal(key[:len(nIter.namespace)], nIter.namespace) {
-		return false
-	}
-
-	return true
 }
 
 func (nIter *namespaceIterator) Next() (bool, error) {

--- a/test/integration/iterator/prefix_test.go
+++ b/test/integration/iterator/prefix_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
-	"github.com/sourcenetwork/corekv/test/state"
 )
 
 func TestIteratorPrefix(t *testing.T) {
@@ -33,11 +32,8 @@ func TestIteratorPrefix(t *testing.T) {
 	test.Execute(t)
 }
 
-func TestIteratorPrefix_DoesNotReturnSelf_Memory(t *testing.T) {
+func TestIteratorPrefix_DoesNotReturnSelf(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
-		},
 		Actions: []action.Action{
 			action.Set([]byte("k"), []byte("v")),
 			action.Set([]byte("k1"), []byte("v1")),
@@ -46,7 +42,7 @@ func TestIteratorPrefix_DoesNotReturnSelf_Memory(t *testing.T) {
 					Prefix: []byte("k"),
 				},
 				Expected: []action.KeyValue{
-					// `k` must not be yielded, as prefxes do not contain themselves
+					{Key: []byte("k"), Value: []byte("v")},
 					{Key: []byte("k1"), Value: []byte("v1")},
 				},
 			},
@@ -56,23 +52,15 @@ func TestIteratorPrefix_DoesNotReturnSelf_Memory(t *testing.T) {
 	test.Execute(t)
 }
 
-// This test documents unwanted behaviour, it is tracked by:
-// https://github.com/sourcenetwork/corekv/issues/27
-func TestIteratorPrefix_DoesNotReturnSelf_Badger(t *testing.T) {
+func TestIteratorPrefix_DoesNotReturnSelf_NamespaceMatch(t *testing.T) {
 	test := &integration.Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
-		},
 		Actions: []action.Action{
-			action.Set([]byte("k"), []byte("v")),
+			action.Set([]byte("namespace"), []byte("namespace exact match")),
+			action.Namespace([]byte("namespace")),
 			action.Set([]byte("k1"), []byte("v1")),
 			&action.Iterate{
-				IterOptions: corekv.IterOptions{
-					Prefix: []byte("k"),
-				},
 				Expected: []action.KeyValue{
-					// `k` should not be yielded, but it is.
-					{Key: []byte("k"), Value: []byte("v")},
+					{Key: []byte(""), Value: []byte("namespace exact match")},
 					{Key: []byte("k1"), Value: []byte("v1")},
 				},
 			},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #27

## Description

Returns exact prefix match from memory iterator, matching the badger behaviour.

Also removes some dead code I accidentally left in from a previous PR.
