### PR TITLE
test: Introduce complexity multiplier test system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,37 @@ on:
       - main
 
 jobs:
-  run-tests:
+  test:
+    name: Run tests job
+
+    strategy:
+        matrix:
+          store: [memory, badger]
+          namespace: [namespace, none]
+
+    runs-on: ubuntu-latest
+
+    env:
+      CORE_KV_MULTIPLIERS: ${{ matrix.store }},${{ matrix.namespace }}
+
+    steps:
+      - name: Checkout code into the directory
+        uses: actions/checkout@v3
+
+      - name: Setup Go environment explicitly
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.21"
+          check-latest: true
+
+      - name: Build dependencies
+        run: |
+          make deps:test-ci
+
+      - name: Run tests
+        run: make test:ci
+
+  tests-os:
     name: Run tests job
 
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,19 @@ test:
 	@$(MAKE) clean
 	go test ./...
 
+.PHONY: test\:all
+test\:all:
+# Environment variable changes do not invalidate the go test cache, so it is important
+# for us to clean between each run.
+	@$(MAKE) clean
+	CORE_KV_MULTIPLIERS="memory" go test ./...
+	@$(MAKE) clean
+	CORE_KV_MULTIPLIERS="badger" go test ./...
+	@$(MAKE) clean
+	CORE_KV_MULTIPLIERS="namespace,memory" go test ./...
+	@$(MAKE) clean
+	CORE_KV_MULTIPLIERS="namespace,badger" go test ./...
+
 .PHONY: test\:ci
 test\:ci:
 # We do not make the deps here, the ci does that seperately to avoid compiling stuff

--- a/test/action/new.go
+++ b/test/action/new.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	badgerds "github.com/dgraph-io/badger/v4"
-	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/badger"
 	"github.com/sourcenetwork/corekv/memory"
 	"github.com/sourcenetwork/corekv/test/state"
@@ -10,29 +9,47 @@ import (
 )
 
 // NewStore action will create a new [corekv.Store] when executed.
+//
+// This action type is a placeholder and will be replaced depending
+// on the active complexity multipliers.
 type NewStore struct{}
 
 var _ Action = (*NewStore)(nil)
 
 // New creates a new [*NewStore] action that will create a new [corekv.Store] when executed.
+//
+// The instance returned by this function is a placeholder and will be replaced depending
+// on the active complexity multipliers.
 func New() *NewStore {
 	return &NewStore{}
 }
 
 func (a *NewStore) Execute(s *state.State) {
-	var store corekv.Store
+	s.T.Fatalf("Store type multiplier not specified")
+}
 
-	switch s.Options.StoreType {
-	case state.BadgerStoreType:
-		var err error
-		// This repo is not currently too concerned with badger-file vs badger-memory, so we only bother
-		// testing with badger-memory at the moment.
-		store, err = badger.NewDatastore("", badgerds.DefaultOptions("").WithInMemory(true))
-		require.NoError(s.T, err)
+// NewMemoryStore action will create a new [memory.Datastore] when executed.
+type NewMemoryStore struct{}
 
-	case state.MemoryStoreType:
-		store = memory.NewDatastore(s.Ctx)
-	}
+var _ Action = (*NewMemoryStore)(nil)
+
+func (a *NewMemoryStore) Execute(s *state.State) {
+	store := memory.NewDatastore(s.Ctx)
+
+	s.Rootstore = store
+	s.Store = store
+}
+
+// NewBadgerStore action will create a new badger [corekv.Store] when executed.
+type NewBadgerStore struct{}
+
+var _ Action = (*NewBadgerStore)(nil)
+
+func (a *NewBadgerStore) Execute(s *state.State) {
+	// This repo is not currently too concerned with badger-file vs badger-memory, so we only bother
+	// testing with badger-memory at the moment.
+	store, err := badger.NewDatastore("", badgerds.DefaultOptions("").WithInMemory(true))
+	require.NoError(s.T, err)
 
 	s.Rootstore = store
 	s.Store = store

--- a/test/integration/delete_close_test.go
+++ b/test/integration/delete_close_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/sourcenetwork/corekv/test/action"
-	"github.com/sourcenetwork/corekv/test/state"
+	"github.com/sourcenetwork/corekv/test/multiplier"
 )
 
 func TestDeleteClose_MemoryStoreDeleteOnClosedStore_Errors(t *testing.T) {
 	test := &Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
+		Includes: []string{
+			multiplier.Memory,
 		},
 		Actions: []action.Action{
 			action.Close(),
@@ -23,8 +23,8 @@ func TestDeleteClose_MemoryStoreDeleteOnClosedStore_Errors(t *testing.T) {
 
 func TestDeleteClose_BadgerStoreDeleteOnClosedStore_Errors(t *testing.T) {
 	test := &Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
+		Includes: []string{
+			multiplier.Badger,
 		},
 		Actions: []action.Action{
 			action.Close(),

--- a/test/integration/set_close_test.go
+++ b/test/integration/set_close_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 
 	"github.com/sourcenetwork/corekv/test/action"
-	"github.com/sourcenetwork/corekv/test/state"
+	"github.com/sourcenetwork/corekv/test/multiplier"
 )
 
 func TestSetClose_MemoryStoreSetOnClosedStore_Errors(t *testing.T) {
 	test := &Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.MemoryStoreType,
+		Includes: []string{
+			multiplier.Memory,
 		},
 		Actions: []action.Action{
 			action.Close(),
@@ -23,8 +23,8 @@ func TestSetClose_MemoryStoreSetOnClosedStore_Errors(t *testing.T) {
 
 func TestSetClose_BadgerStoreSetOnClosedStore_Errors(t *testing.T) {
 	test := &Test{
-		SupportedStoreTypes: []state.StoreType{
-			state.BadgerStoreType,
+		Includes: []string{
+			multiplier.Badger,
 		},
 		Actions: []action.Action{
 			action.Close(),

--- a/test/multiplier/multiplier.go
+++ b/test/multiplier/multiplier.go
@@ -21,6 +21,13 @@ type Name = string
 // a new filter operation, the new action must be tested both with, and without
 // a transaction - the transaction concept multiplies the complexity of the system.
 //
+// The identification and automatic representation of complexity multipiers are critical
+// to the long term maintainability and scalability of a codebase. Without them, introducing
+// fairly simple features becomes high risk, and requires a forever growing number of manually
+// constructed tests, when the feature developer needs to remember, and write tests for every
+// multiplier that affects the feature under test.  This is error prone, very tedious, and
+// distracts from the feature itself - often degrading the quality of both test and production code.
+//
 // Complexity multipliers defined using this type may redefine the set of test actions
 // to perform within a test, allowing a single test to scale with the complexity
 // multiplier.  For example, applying a 'namespace' multplier may add an action that

--- a/test/multiplier/multiplier.go
+++ b/test/multiplier/multiplier.go
@@ -1,0 +1,128 @@
+package multiplier
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+)
+
+var activeMultipliers []Multiplier
+var availableMultipliers []Multiplier
+
+type Name = string
+
+// Multiplier represents a complexity multiplier of the system under test.
+//
+// It represents a concept that multiplies the surface area and complexity
+// of other proximal features, for example, database transactions are
+// complexity modifiers, as when adding many new database actions such as
+// a new filter operation, the new action must be tested both with, and without
+// a transaction - the transaction concept multiplies the complexity of the system.
+//
+// Complexity multipliers defined using this type may redefine the set of test actions
+// to perform within a test, allowing a single test to scale with the complexity
+// multiplier.  For example, applying a 'namespace' multplier may add an action that
+// namespaces the store under test, reducing, but not removing, testing cost of the
+// namespace multiplier.
+type Multiplier interface {
+	// Name returns the unique name of the multiplier.
+	Name() Name
+
+	// Apply applies the complexity multiplier to the given action set, returning a new
+	// action set testing the multiplier.
+	Apply(source action.Actions) action.Actions
+}
+
+// Register adds the given multiplier to the internal set of available multipliers.
+//
+// Multipliers must be registered before calling [Init] in order to be applied.
+func Register(multiplier Multiplier) {
+	availableMultipliers = append(availableMultipliers, multiplier)
+}
+
+// Init initializes the multiplier engine, determining which multipliers are to
+// be applied to action sets.
+//
+// It must be called after all required [Multiplier]s are [Register]ed.
+//
+// It will check to see if the given environment variable is set, and if so,
+// sources the comma sperated set of multiplier names from it.  If the
+// environment variable is not set, it will use the provided defaults.
+//
+// Multipliers will be applied in the order in which they are given.
+func Init(envVarName string, defaults ...Name) {
+	var multiplierNames []string
+	multipliersString, ok := os.LookupEnv(envVarName)
+	if ok {
+		multiplierNames = strings.Split(multipliersString, ",")
+	} else {
+		multiplierNames = defaults
+	}
+
+	for i, name := range multiplierNames {
+		multiplierNames[i] = strings.TrimSpace(name)
+	}
+
+	availableMultipliersByName := make(map[Name]Multiplier, len(availableMultipliers))
+	for _, multiplier := range availableMultipliers {
+		availableMultipliersByName[multiplier.Name()] = multiplier
+	}
+
+	activeMultipliers = make([]Multiplier, 0, len(multiplierNames))
+	for _, multiplierName := range multiplierNames {
+		if multiplier, ok := availableMultipliersByName[multiplierName]; ok {
+			activeMultipliers = append(activeMultipliers, multiplier)
+		}
+	}
+}
+
+// Apply applies all active multipliers to the given action set, in the order in which the
+// multipliers are provided.
+func Apply(actions action.Actions) action.Actions {
+	for _, multiplier := range activeMultipliers {
+		actions = multiplier.Apply(actions)
+	}
+
+	return actions
+}
+
+// Skip skips the test if:
+//   - The active set of multipliers does not contain a multiplier with a name exactly matching
+//     a value in the given `includes` set.
+//   - The active set of multipliers contains a multiplier with a name exactly matching
+//     a value in the given `excludes` set.
+func Skip(t testing.TB, includes []Name, excludes []Name) {
+	for _, multiplier := range activeMultipliers {
+		for _, exclude := range excludes {
+			if multiplier.Name() == exclude {
+				t.Skipf("skipping, multiplier is excluded. Name: %s", exclude)
+			}
+		}
+	}
+
+	for _, include := range includes {
+		included := false
+		for _, multiplier := range activeMultipliers {
+			if multiplier.Name() == include {
+				included = true
+				break
+			}
+		}
+
+		if !included {
+			t.Skipf("skipping, required multiplier is not included. Name: %s", include)
+		}
+	}
+}
+
+// Get returns a comma-seperated string containing the current active multiplier names.
+func Get() string {
+	multipliers := make([]string, len(activeMultipliers))
+	for i, multiplier := range activeMultipliers {
+		multipliers[i] = multiplier.Name()
+	}
+
+	return strings.Join(multipliers, ",")
+}

--- a/test/multiplier/multiplier.go
+++ b/test/multiplier/multiplier.go
@@ -11,6 +11,9 @@ import (
 var activeMultipliers []Multiplier
 var availableMultipliers []Multiplier
 
+// Name represents the unique name of a multiplier.
+//
+// The alias provides a more descriptive type to use besides `string`.
 type Name = string
 
 // Multiplier represents a complexity multiplier of the system under test.

--- a/test/multiplier/namespace.go
+++ b/test/multiplier/namespace.go
@@ -1,0 +1,29 @@
+package multiplier
+
+import "github.com/sourcenetwork/corekv/test/action"
+
+func init() {
+	Register(&namespace{})
+}
+
+const Namespace Name = "namespace"
+
+// namespace represents the namespacing complexity multiplier.
+//
+// Applying the multiplier will prepend a [action.NamespaceStore] action
+// to the front of the action set.
+type namespace struct{}
+
+var _ Multiplier = (*namespace)(nil)
+
+func (n *namespace) Name() Name {
+	return Namespace
+}
+
+func (n *namespace) Apply(source action.Actions) action.Actions {
+	result := make(action.Actions, 1, len(source)+1)
+	result[0] = action.Namespace([]byte("/example"))
+	result = append(result, source...)
+
+	return result
+}

--- a/test/multiplier/store_type.go
+++ b/test/multiplier/store_type.go
@@ -1,0 +1,68 @@
+package multiplier
+
+import (
+	"github.com/sourcenetwork/corekv/test/action"
+)
+
+func init() {
+	Register(&badger{})
+	Register(&memory{})
+}
+
+const Badger Name = "badger"
+
+// badger represents the badger store complexity multiplier.
+//
+// Applying the multiplier will replace all [action.NewStore] actions
+// with [action.NewBadgerStore] instances.
+type badger struct{}
+
+var _ Multiplier = (*badger)(nil)
+
+func (n *badger) Name() Name {
+	return Badger
+}
+
+func (n *badger) Apply(source action.Actions) action.Actions {
+	result := make([]action.Action, len(source))
+
+	for i, sourceAction := range source {
+		_, ok := sourceAction.(*action.NewStore)
+		if ok {
+			result[i] = &action.NewBadgerStore{}
+		} else {
+			result[i] = sourceAction
+		}
+	}
+
+	return result
+}
+
+const Memory Name = "memory"
+
+// memory represents the memory store complexity multiplier.
+//
+// Applying the multiplier will replace all [action.NewStore] actions
+// with [action.NewMemoryStore] instances.
+type memory struct{}
+
+var _ Multiplier = (*memory)(nil)
+
+func (n *memory) Name() Name {
+	return Memory
+}
+
+func (n *memory) Apply(source action.Actions) action.Actions {
+	result := make([]action.Action, len(source))
+
+	for i, sourceAction := range source {
+		_, ok := sourceAction.(*action.NewStore)
+		if ok {
+			result[i] = &action.NewMemoryStore{}
+		} else {
+			result[i] = sourceAction
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #49

## Description

Introduces a complexity multiplier test system, replacing the old system of hard coded `Test` properties.

A new multiplier will be added soon in another PR, to test transactions.

I plan on introducing this system to Defra soon after integrating CoreKV into Defra, and refactoring Defra actions to more closely match the CoreKV system.  I hope this will eventually cover client types, mutation types, collection/schema patches, views, secondary indexes, P2P, field kinds, crdt types and any other complexity multipliers we introduce.

I suggest reading the documentation for `Multiplier` in test/multiplier/multiplier.go before anything else.