### PR TITLE
fix: Handle namespace iterator if no prefix/start/end

### DIFF
--- a/memory/iter.go
+++ b/memory/iter.go
@@ -33,6 +33,9 @@ type iterator struct {
 	// https://github.com/tidwall/btree/issues/46 - these properties and the work around
 	// should be removed when the btree bug is fixed.
 	//
+	// Currently it is believed that this is only required for the `Reverse` option (tidwall bug
+	// appears to be directional).
+	//
 	// `TestBTreePrevBug` also documents this issue.
 	lastItem  dsItem
 	firstItem dsItem

--- a/test/integration/iterator/end_namespace_test.go
+++ b/test/integration/iterator/end_namespace_test.go
@@ -1,0 +1,33 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorEndNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k5"), []byte("v5")),
+			action.Namespace([]byte("namespace")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.Set([]byte("k3"), []byte("v3")),
+			action.Set([]byte("k4"), []byte("v4")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					End: []byte("k4"),
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k2"), Value: []byte("v2")},
+					{Key: []byte("k3"), Value: []byte("v3")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/namespace_test.go
+++ b/test/integration/iterator/namespace_test.go
@@ -1,0 +1,26 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorNamespace_DoesNotReturnSelf_NamespaceMatch(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("namespace"), []byte("namespace exact match")),
+			action.Namespace([]byte("namespace")),
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterate{
+				Expected: []action.KeyValue{
+					{Key: []byte(""), Value: []byte("namespace exact match")},
+					{Key: []byte("k1"), Value: []byte("v1")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/prefix_namespace_test.go
+++ b/test/integration/iterator/prefix_namespace_test.go
@@ -3,29 +3,12 @@ package iterator
 import (
 	"testing"
 
+	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
 )
 
-func TestIteratorNamespace_DoesNotReturnSelf_NamespaceMatch(t *testing.T) {
-	test := &integration.Test{
-		Actions: []action.Action{
-			action.Set([]byte("namespace"), []byte("namespace exact match")),
-			action.Namespace([]byte("namespace")),
-			action.Set([]byte("k1"), []byte("v1")),
-			&action.Iterate{
-				Expected: []action.KeyValue{
-					{Key: []byte(""), Value: []byte("namespace exact match")},
-					{Key: []byte("k1"), Value: []byte("v1")},
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}
-
-func TestIteratorNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
+func TestIteratorPrefixNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
@@ -34,6 +17,9 @@ func TestIteratorNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
 			action.Set([]byte("k2"), []byte("v2")),
 			action.Set([]byte("k3"), []byte("v3")),
 			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Prefix: []byte("k"),
+				},
 				Expected: []action.KeyValue{
 					{Key: []byte("k2"), Value: []byte("v2")},
 					{Key: []byte("k3"), Value: []byte("v3")},

--- a/test/integration/iterator/prefix_test.go
+++ b/test/integration/iterator/prefix_test.go
@@ -51,21 +51,3 @@ func TestIteratorPrefix_DoesNotReturnSelf(t *testing.T) {
 
 	test.Execute(t)
 }
-
-func TestIteratorPrefix_DoesNotReturnSelf_NamespaceMatch(t *testing.T) {
-	test := &integration.Test{
-		Actions: []action.Action{
-			action.Set([]byte("namespace"), []byte("namespace exact match")),
-			action.Namespace([]byte("namespace")),
-			action.Set([]byte("k1"), []byte("v1")),
-			&action.Iterate{
-				Expected: []action.KeyValue{
-					{Key: []byte(""), Value: []byte("namespace exact match")},
-					{Key: []byte("k1"), Value: []byte("v1")},
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}

--- a/test/integration/iterator/start_end_namespace_test.go
+++ b/test/integration/iterator/start_end_namespace_test.go
@@ -1,0 +1,34 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorStartEndNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k5"), []byte("v5")),
+			action.Namespace([]byte("namespace")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.Set([]byte("k3"), []byte("v3")),
+			action.Set([]byte("k4"), []byte("v4")),
+			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Start: []byte("k2"),
+					End:   []byte("k4"),
+				},
+				Expected: []action.KeyValue{
+					{Key: []byte("k2"), Value: []byte("v2")},
+					{Key: []byte("k3"), Value: []byte("v3")},
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/start_namespace_test.go
+++ b/test/integration/iterator/start_namespace_test.go
@@ -3,29 +3,12 @@ package iterator
 import (
 	"testing"
 
+	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
 )
 
-func TestIteratorNamespace_DoesNotReturnSelf_NamespaceMatch(t *testing.T) {
-	test := &integration.Test{
-		Actions: []action.Action{
-			action.Set([]byte("namespace"), []byte("namespace exact match")),
-			action.Namespace([]byte("namespace")),
-			action.Set([]byte("k1"), []byte("v1")),
-			&action.Iterate{
-				Expected: []action.KeyValue{
-					{Key: []byte(""), Value: []byte("namespace exact match")},
-					{Key: []byte("k1"), Value: []byte("v1")},
-				},
-			},
-		},
-	}
-
-	test.Execute(t)
-}
-
-func TestIteratorNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
+func TestIteratorStartNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
 	test := &integration.Test{
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
@@ -34,6 +17,9 @@ func TestIteratorNamespace_ExcludesItemsOutsideOfNamespace(t *testing.T) {
 			action.Set([]byte("k2"), []byte("v2")),
 			action.Set([]byte("k3"), []byte("v3")),
 			&action.Iterate{
+				IterOptions: corekv.IterOptions{
+					Start: []byte("k2"),
+				},
 				Expected: []action.KeyValue{
 					{Key: []byte("k2"), Value: []byte("v2")},
 					{Key: []byte("k3"), Value: []byte("v3")},


### PR DESCRIPTION
## Relevant issue(s)

Resolves #60

## Description

Handles namespace iterator if no prefix/start/end provided.

Includes a lazy workaround for a known bug in the tidwall/btree implementation that was hit when fixing #60.  Performance deemed to be low enough priority in the memory store iterator constructor at the moment to tolerate a simple workaround.
