### PR TITLE
feat: Add DropAll support

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -14,6 +14,7 @@ type Datastore struct {
 	db *badger.DB
 }
 
+var _ corekv.TxnStore = (*Datastore)(nil)
 var _ corekv.Dropable = (*Datastore)(nil)
 
 func NewDatastore(path string, opts badger.Options) (*Datastore, error) {

--- a/badger/badger.go
+++ b/badger/badger.go
@@ -14,6 +14,8 @@ type Datastore struct {
 	db *badger.DB
 }
 
+var _ corekv.Dropable = (*Datastore)(nil)
+
 func NewDatastore(path string, opts badger.Options) (*Datastore, error) {
 	opts.Dir = path
 	opts.ValueDir = path
@@ -90,6 +92,10 @@ func (b *Datastore) Iterator(ctx context.Context, iterOpts corekv.IterOptions) c
 	})
 	return it
 
+}
+
+func (d *Datastore) DropAll() error {
+	return d.db.DropAll()
 }
 
 func (b *Datastore) NewTxn(readonly bool) corekv.Txn {

--- a/kv.go
+++ b/kv.go
@@ -124,6 +124,17 @@ type Iterator interface {
 	Close() error
 }
 
+// Dropable is an optionall interface implemented by some Stores.
+//
+// It provides a convienient and cheap way of deleting all the data in an existing store.
+type Dropable interface {
+	// DropAll deletes all the data stored in the store.
+	//
+	// Concurrent writes will be blocked, however depending on the underlying store implementation,
+	// concurrent reads may not be.  Badger does not block concurrent reads, but Memory store does.
+	DropAll() error
+}
+
 // Store contains all the functions required for interacting with a store.
 type Store interface {
 	Reader

--- a/kv.go
+++ b/kv.go
@@ -124,9 +124,9 @@ type Iterator interface {
 	Close() error
 }
 
-// Dropable is an optionall interface implemented by some Stores.
+// Dropable is an optional interface implemented by some Stores.
 //
-// It provides a convienient and cheap way of deleting all the data in an existing store.
+// It provides a convenient and cheap way of deleting all the data in an existing store.
 type Dropable interface {
 	// DropAll deletes all the data stored in the store.
 	//

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -68,6 +68,7 @@ type Datastore struct {
 }
 
 var _ corekv.TxnStore = (*Datastore)(nil)
+var _ corekv.Dropable = (*Datastore)(nil)
 
 // NewDatastore constructs an empty Datastore.
 func NewDatastore(ctx context.Context) *Datastore {
@@ -171,6 +172,11 @@ func (d *Datastore) Has(ctx context.Context, key []byte) (exists bool, err error
 	}
 	result := get(d.values, key, d.getVersion())
 	return result.key != nil && !result.isDeleted, nil
+}
+
+func (d *Datastore) DropAll() error {
+	d.values.Clear()
+	return nil
 }
 
 // NewTxn return a corekv.Txn datastore based on Datastore.

--- a/test/action/drop_all.go
+++ b/test/action/drop_all.go
@@ -1,0 +1,28 @@
+package action
+
+import (
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/state"
+	"github.com/stretchr/testify/require"
+)
+
+// DropAllItems action will drop all the items in the store if the store
+// supports it.  Otherwise skips the test.
+type DropAllItems struct{}
+
+var _ Action = (*DropAllItems)(nil)
+
+// Cancel returns a new [*CancelCtx] action that will cancel the state's context when executed.
+func DropAll() *DropAllItems {
+	return &DropAllItems{}
+}
+
+func (a *DropAllItems) Execute(s *state.State) {
+	dropable, ok := s.Store.(corekv.Dropable)
+	if !ok {
+		s.T.Skipf("Store does not support DropAll, test is irrelevant")
+	}
+
+	err := dropable.DropAll()
+	require.NoError(s.T, err)
+}

--- a/test/integration/drop_all_test.go
+++ b/test/integration/drop_all_test.go
@@ -1,0 +1,18 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+)
+
+func TestDropAll(t *testing.T) {
+	test := &Test{
+		Actions: []action.Action{
+			action.New(),
+			action.DropAll(),
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/set_drop_all_has_test.go
+++ b/test/integration/set_drop_all_has_test.go
@@ -1,0 +1,21 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+)
+
+func TestSetDropAllHas(t *testing.T) {
+	test := &Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k2"), []byte("v2")),
+			action.DropAll(),
+			action.Has([]byte("k1"), false),
+			action.Has([]byte("k2"), false),
+		},
+	}
+
+	test.Execute(t)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #57

## Description

Adds optional DropAll support, allowing the quick and easy clearing of an existing store.

It has not been added to the namespace, or transactions store as it is not required for Defra, is a bit of a hassle, and doesn't really make much sense.

 This PR is based off of #62 - please do not review the first commit here.