### PR TITLE
fix: Return error when iterating through closed store

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -70,7 +70,7 @@ type Reader interface {
 	Has(ctx context.Context, key []byte) (bool, error)
 
 	// Iterator returns a read-only iterator using the given options.
-	Iterator(ctx context.Context, opts IterOptions) Iterator
+	Iterator(ctx context.Context, opts IterOptions) (Iterator, error)
 }
 
 // Writer contains functions for mutating values within a store.

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -223,11 +223,11 @@ func (d *Datastore) Set(ctx context.Context, key []byte, value []byte) (err erro
 	return tx.Commit()
 }
 
-func (d *Datastore) Iterator(ctx context.Context, opts corekv.IterOptions) corekv.Iterator {
+func (d *Datastore) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
 	if opts.Prefix != nil {
-		return newPrefixIter(d.values, opts.Prefix, opts.Reverse, d.getVersion())
+		return newPrefixIter(d.values, opts.Prefix, opts.Reverse, d.getVersion()), nil
 	}
-	return newRangeIter(d.values, opts.Start, opts.End, opts.Reverse, d.getVersion())
+	return newRangeIter(d.values, opts.Start, opts.End, opts.Reverse, d.getVersion()), nil
 }
 
 // purgeOldVersions will execute the purge once a day or when explicitly requested.

--- a/memory/txn.go
+++ b/memory/txn.go
@@ -173,20 +173,20 @@ func (t *basicTxn) Set(ctx context.Context, key []byte, value []byte) error {
 	return nil
 }
 
-func (t *basicTxn) Iterator(ctx context.Context, opts corekv.IterOptions) corekv.Iterator {
+func (t *basicTxn) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
 	if opts.Prefix != nil {
 		return &txnIterator{
 			opts:      opts,
 			txnIter:   newPrefixIter(t.ops, opts.Prefix, opts.Reverse, t.getTxnVersion()),
 			storeIter: newPrefixIter(t.ds.values, opts.Prefix, opts.Reverse, t.getDSVersion()),
-		}
+		}, nil
 	}
 
 	return &txnIterator{
 		opts:      opts,
 		txnIter:   newRangeIter(t.ops, opts.Start, opts.End, opts.Reverse, t.getTxnVersion()),
 		storeIter: newRangeIter(t.ds.values, opts.Start, opts.End, opts.Reverse, t.getDSVersion()),
-	}
+	}, nil
 }
 
 type txnIterator struct {

--- a/memory/txn.go
+++ b/memory/txn.go
@@ -174,18 +174,24 @@ func (t *basicTxn) Set(ctx context.Context, key []byte, value []byte) error {
 }
 
 func (t *basicTxn) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
+	t.closeLk.RLock()
+	defer t.closeLk.RUnlock()
+	if t.closed {
+		return nil, corekv.ErrDBClosed
+	}
+
 	if opts.Prefix != nil {
 		return &txnIterator{
 			opts:      opts,
-			txnIter:   newPrefixIter(t.ops, opts.Prefix, opts.Reverse, t.getTxnVersion()),
-			storeIter: newPrefixIter(t.ds.values, opts.Prefix, opts.Reverse, t.getDSVersion()),
+			txnIter:   newPrefixIter(t.ds, t.ops, opts.Prefix, opts.Reverse, t.getTxnVersion()),
+			storeIter: newPrefixIter(t.ds, t.ds.values, opts.Prefix, opts.Reverse, t.getDSVersion()),
 		}, nil
 	}
 
 	return &txnIterator{
 		opts:      opts,
-		txnIter:   newRangeIter(t.ops, opts.Start, opts.End, opts.Reverse, t.getTxnVersion()),
-		storeIter: newRangeIter(t.ds.values, opts.Start, opts.End, opts.Reverse, t.getDSVersion()),
+		txnIter:   newRangeIter(t.ds, t.ops, opts.Start, opts.End, opts.Reverse, t.getTxnVersion()),
+		storeIter: newRangeIter(t.ds, t.ds.values, opts.Start, opts.End, opts.Reverse, t.getDSVersion()),
 	}, nil
 }
 

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -116,7 +116,7 @@ func prefixed(prefix, key []byte) []byte {
 }
 
 // Iterator creates a new iterator instance
-func (nstore *Datastore) Iterator(ctx context.Context, opts corekv.IterOptions) corekv.Iterator {
+func (nstore *Datastore) Iterator(ctx context.Context, opts corekv.IterOptions) (corekv.Iterator, error) {
 	if opts.Prefix != nil {
 		opts.Prefix = nstore.prefixed(opts.Prefix)
 	} else if opts.Start != nil || opts.End != nil {
@@ -135,10 +135,15 @@ func (nstore *Datastore) Iterator(ctx context.Context, opts corekv.IterOptions) 
 		opts.Prefix = nstore.prefixed(opts.Prefix)
 	}
 
+	iterator, err := nstore.store.Iterator(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	return &namespaceIterator{
 		namespace: nstore.namespace,
-		it:        nstore.store.Iterator(ctx, opts),
-	}
+		it:        iterator,
+	}, nil
 }
 
 type namespaceIterator struct {

--- a/test/action/iterate.go
+++ b/test/action/iterate.go
@@ -32,7 +32,8 @@ type Iterate struct {
 var _ Action = (*Iterate)(nil)
 
 func (a *Iterate) Execute(s *state.State) {
-	iterator := s.Store.Iterator(s.Ctx, a.IterOptions)
+	iterator, err := s.Store.Iterator(s.Ctx, a.IterOptions)
+	require.NoError(s.T, err)
 
 	entries := make([]KeyValue, 0)
 	for {
@@ -54,7 +55,7 @@ func (a *Iterate) Execute(s *state.State) {
 		})
 	}
 
-	err := iterator.Close()
+	err = iterator.Close()
 	require.NoError(s.T, err)
 
 	require.Equal(s.T, a.Expected, entries)

--- a/test/action/iterate.go
+++ b/test/action/iterate.go
@@ -33,7 +33,11 @@ var _ Action = (*Iterate)(nil)
 
 func (a *Iterate) Execute(s *state.State) {
 	iterator, err := s.Store.Iterator(s.Ctx, a.IterOptions)
-	require.NoError(s.T, err)
+	if err != nil {
+		expectError(s, err, a.ExpectedError)
+		require.Nil(s.T, iterator)
+		return
+	}
 
 	entries := make([]KeyValue, 0)
 	for {

--- a/test/action/iterator.go
+++ b/test/action/iterator.go
@@ -18,13 +18,14 @@ type Iterator struct {
 var _ Action = (*Iterator)(nil)
 
 func (a *Iterator) Execute(s *state.State) {
-	iterator := s.Store.Iterator(s.Ctx, a.IterOptions)
+	iterator, err := s.Store.Iterator(s.Ctx, a.IterOptions)
+	require.NoError(s.T, err)
 
 	for _, action := range a.ChildActions {
 		action.Execute(s, iterator)
 	}
 
-	err := iterator.Close()
+	err = iterator.Close()
 	require.NoError(s.T, err)
 }
 

--- a/test/integration/iterator/close_next_test.go
+++ b/test/integration/iterator/close_next_test.go
@@ -1,0 +1,24 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorCloseNext(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Iterator{
+				ChildActions: []action.IteratorAction{
+					action.CloseRoot(),
+					action.NextE(corekv.ErrDBClosed.Error()),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/close_next_value_test.go
+++ b/test/integration/iterator/close_next_value_test.go
@@ -1,0 +1,34 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/multiplier"
+)
+
+func TestIteratorCloseNextValue_NoTxn(t *testing.T) {
+	test := &integration.Test{
+		Excludes: []multiplier.Name{
+			// Test behaviour varies a bit with the txn multipliers at the moment,
+			// with the stores all failing in slightly different ways.
+			// https://github.com/sourcenetwork/corekv/issues/68
+			multiplier.TxnDiscard,
+			multiplier.TxnCommit,
+			multiplier.TxnMulti,
+		},
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			&action.Iterator{
+				ChildActions: []action.IteratorAction{
+					action.Next(true),
+					action.CloseRoot(),
+					action.Value([]byte("v1")),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/close_seek_test.go
+++ b/test/integration/iterator/close_seek_test.go
@@ -1,0 +1,24 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorCloseSeek(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			&action.Iterator{
+				ChildActions: []action.IteratorAction{
+					action.CloseRoot(),
+					action.SeekE([]byte("any key"), corekv.ErrDBClosed.Error()),
+				},
+			},
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/close_test.go
+++ b/test/integration/iterator/close_test.go
@@ -1,0 +1,22 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/sourcenetwork/corekv/test/action"
+	"github.com/sourcenetwork/corekv/test/integration"
+)
+
+func TestIteratorClose(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Close(),
+			&action.Iterate{
+				ExpectedError: corekv.ErrDBClosed.Error(),
+			},
+		},
+	}
+
+	test.Execute(t)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #67

## Description

Returns an error when iterating through closed store instead of panicing.

This was particularly annoying in Defra, as background routines would often panic in test teardown, making them fairly flaky. 