### PR TITLE
refactor: Remove discard return value

### DIFF
--- a/kv.go
+++ b/kv.go
@@ -167,5 +167,5 @@ type Txn interface {
 
 	// Discard discards all changes made via this object so far, returning
 	// it to the state it was at at time of construction.
-	Discard() error
+	Discard()
 }

--- a/memory/txn.go
+++ b/memory/txn.go
@@ -321,20 +321,19 @@ func (iter *txnIterator) Close() error {
 }
 
 func (t *basicTxn) Close() error {
-	return t.Discard()
+	t.Discard()
+	return nil
 }
 
 // Discard removes all the operations added to the transaction.
-func (t *basicTxn) Discard() error {
+func (t *basicTxn) Discard() {
 	if t.discarded {
-		return nil
+		return
 	}
 
 	t.ops.Clear()
 	t.clearInFlightTxn()
 	t.discarded = true
-
-	return nil
 }
 
 // Commit saves the operations to the underlying datastore.

--- a/namespace/namespace.go
+++ b/namespace/namespace.go
@@ -181,8 +181,8 @@ func (txn *Txn) Commit() error {
 	return txn.txn.Commit()
 }
 
-func (txn *Txn) Discard() error {
-	return txn.txn.Discard()
+func (txn *Txn) Discard() {
+	txn.txn.Discard()
 }
 
 func cp(bz []byte) (ret []byte) {

--- a/test/action/txn.go
+++ b/test/action/txn.go
@@ -127,8 +127,7 @@ func DiscardI(id int) *DiscardTxn {
 func (a *DiscardTxn) Execute(s *state.State) {
 	txn := s.Txns[a.ID]
 
-	err := txn.Discard()
-	require.NoError(s.T, err)
+	txn.Discard()
 }
 
 // CommitTxn commits the given transaction when executed.


### PR DESCRIPTION
## Relevant issue(s)

Resolves #70

## Description

Removes the discard return value, as no implementations ever return a value and it made calling `Discard` in a `defer` undesirable (requires ignoring potential errors, and adding a `//nolint`).

Please do not review the first commit here.  I have based this commit off of another pending PR to make it's integration into Defra easier (in the Defra CI).