### PR TITLE
refactor: Remove Close from Txn interface

### DIFF
--- a/badger/badger.go
+++ b/badger/badger.go
@@ -184,11 +184,6 @@ func (txn *bTxn) Discard() {
 	txn.t.Discard()
 }
 
-func (t *bTxn) Close() error {
-	t.Discard()
-	return nil
-}
-
 var badgerErrToKVErrMap = map[error]error{
 	badger.ErrEmptyKey:     corekv.ErrEmptyKey,
 	badger.ErrKeyNotFound:  corekv.ErrNotFound,

--- a/kv.go
+++ b/kv.go
@@ -87,6 +87,12 @@ type Writer interface {
 	Delete(ctx context.Context, key []byte) error
 }
 
+// ReaderWriter contains the functions for reading and writing values within the store.
+type ReaderWriter interface {
+	Reader
+	Writer
+}
+
 // Iterator is a read-only iterator that allows iteration over the underlying
 // store (or a part of it).
 //
@@ -137,8 +143,7 @@ type Dropable interface {
 
 // Store contains all the functions required for interacting with a store.
 type Store interface {
-	Reader
-	Writer
+	ReaderWriter
 
 	// Close disposes of any resources directly held by the store.
 	//
@@ -159,7 +164,7 @@ type TxnStore interface {
 // and isolates changes made via this object from the underlying store
 // until `Commit` is called.
 type Txn interface {
-	Store
+	ReaderWriter
 
 	// Commit applies all changes made via this [Txn] to the underlying
 	// [Store].

--- a/kv.go
+++ b/kv.go
@@ -160,6 +160,15 @@ type TxnStore interface {
 	NewTxn(readonly bool) Txn
 }
 
+// TxnReaderWriter contains the functions for reading and writing values within the store
+// and supports transactions.
+type TxnReaderWriter interface {
+	ReaderWriter
+
+	// NewTxn returns a new transaction.
+	NewTxn(readonly bool) Txn
+}
+
 // Txn isolates changes made to the underlying store from this object,
 // and isolates changes made via this object from the underlying store
 // until `Commit` is called.

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -101,14 +101,6 @@ func (d *Datastore) Close() error {
 
 	d.closed = true
 	close(d.closing)
-
-	iter := d.inFlightTxn.Iter()
-
-	for iter.Next() {
-		iter.Item().txn.close()
-	}
-	iter.Release()
-
 	return nil
 }
 

--- a/namespace/txn.go
+++ b/namespace/txn.go
@@ -34,15 +34,11 @@ type TxnStore struct {
 	store corekv.TxnStore
 }
 
-var _ corekv.TxnStore = (*TxnStore)(nil)
+var _ corekv.TxnReaderWriter = (*TxnStore)(nil)
 
 func (ntxn *TxnStore) NewTxn(readonly bool) corekv.Txn {
 	txn := ntxn.store.NewTxn(readonly)
 	return WrapTxn(txn, ntxn.namespace)
-}
-
-func (ntxn *TxnStore) Close() error {
-	return ntxn.store.Close()
 }
 
 // WrapTS lets you namespace a transaction store with a given prefix.

--- a/namespace/txn.go
+++ b/namespace/txn.go
@@ -1,0 +1,54 @@
+package namespace
+
+import (
+	"github.com/sourcenetwork/corekv"
+)
+
+type Txn struct {
+	Datastore
+
+	txn corekv.Txn
+}
+
+var _ corekv.Txn = (*Txn)(nil)
+
+// WrapTxn lets you namespace a transaction with a given prefix.
+func WrapTxn(txn corekv.Txn, prefix []byte) *Txn {
+	return &Txn{
+		Datastore: *Wrap(txn, prefix),
+		txn:       txn,
+	}
+}
+
+func (ntxn *Txn) Commit() error {
+	return ntxn.txn.Commit()
+}
+
+func (ntxn *Txn) Discard() {
+	ntxn.txn.Discard()
+}
+
+type TxnStore struct {
+	Datastore
+
+	store corekv.TxnStore
+}
+
+var _ corekv.TxnStore = (*TxnStore)(nil)
+
+func (ntxn *TxnStore) NewTxn(readonly bool) corekv.Txn {
+	txn := ntxn.store.NewTxn(readonly)
+	return WrapTxn(txn, ntxn.namespace)
+}
+
+func (ntxn *TxnStore) Close() error {
+	return ntxn.store.Close()
+}
+
+// WrapTS lets you namespace a transaction store with a given prefix.
+func WrapTS(store corekv.TxnStore, prefix []byte) *TxnStore {
+	return &TxnStore{
+		Datastore: *Wrap(store, prefix),
+		store:     store,
+	}
+}

--- a/test/action/txn.go
+++ b/test/action/txn.go
@@ -93,7 +93,7 @@ func NewTxnI(id int) *CreateNewTxn {
 }
 
 func (a *CreateNewTxn) Execute(s *state.State) {
-	txn := s.Store.(corekv.TxnStore).NewTxn(a.ReadOnly)
+	txn := s.Store.(corekv.TxnReaderWriter).NewTxn(a.ReadOnly)
 
 	if a.ID >= len(s.Txns) {
 		// Expand the slice if needed.

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -25,7 +25,7 @@ type State struct {
 	//
 	// This must be derived from the Rootstore.  For example it may be a namespace within the
 	// Rootstore, or even a transaction of that namespace.
-	Store corekv.Store
+	Store corekv.ReaderWriter
 
 	Txns []corekv.Txn
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #79 

## Description

This PR removes the `Close` method from the `Txn` interface. The reasoning behind this is that only the rootstore should be responsible for closing itself. This means that the namespace store also loses the ability to close the root store. It now implement `ReaderWriter` only.

## How has this been tested?

make test:all

Specify the platform(s) on which this was tested:
- MacOS
