### PR TITLE
refactor: Use interface instead of concrete type with NewIPLDStore

### DIFF
--- a/blockstore/ipld.go
+++ b/blockstore/ipld.go
@@ -13,6 +13,7 @@
 package blockstore
 
 import (
+	"github.com/ipfs/boxo/blockstore"
 	"github.com/ipld/go-ipld-prime/storage"
 	"github.com/ipld/go-ipld-prime/storage/bsadapter"
 )
@@ -24,6 +25,6 @@ type IPLDStore interface {
 }
 
 // NewIPLDStore wraps a Blockstore as an IPLDStore.
-func NewIPLDStore(store *Blockstore) IPLDStore {
+func NewIPLDStore(store blockstore.Blockstore) IPLDStore {
 	return &bsadapter.Adapter{Wrapped: store}
 }


### PR DESCRIPTION
## Relevant issue(s)

Resolves #88 

## Description

The parameter for `NewIPLDStore was accidentally a concrete type instead of the `blockstore.Blockstore` interface.