### PR TITLE
fix: Iterator item version overflow

### DIFF
--- a/memory/iter.go
+++ b/memory/iter.go
@@ -167,7 +167,7 @@ func (iter *iterator) next() (bool, error) {
 	for iter.moveNext() {
 		// Scan through until we reach the next key.
 		// It doesn't matter if it is deleted or not.
-		if !bytes.Equal(previousItem.key, iter.it.Item().key) {
+		if !bytes.Equal(previousItem.key, iter.it.Item().key) && iter.it.Item().version <= iter.version {
 			hasItem = true
 			break
 		}
@@ -325,6 +325,10 @@ func (iter *iterator) loadLatestItem() {
 		// Scan through until we reach the next key.
 		// It doesn't matter if it is deleted or not.
 		if !bytes.Equal(previousItem.key, iter.it.Item().key) {
+			iter.it.Prev()
+			break
+		}
+		if iter.it.Item().version > iter.version {
 			iter.it.Prev()
 			break
 		}

--- a/memory/iter.go
+++ b/memory/iter.go
@@ -131,6 +131,10 @@ func (iter *iterator) valid() bool {
 		return false
 	}
 
+	if iter.it.Item().version > iter.version {
+		return false
+	}
+
 	if iter.it.Item().isDeleted {
 		return false
 	}

--- a/memory/iter_version_test.go
+++ b/memory/iter_version_test.go
@@ -1,0 +1,151 @@
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/btree"
+)
+
+// newTestDatastore creates a minimal datastore suitable for iterator tests.
+func newTestDatastore(ctx context.Context) *Datastore {
+	return NewDatastore(ctx)
+}
+
+// setItem is a test helper that inserts an item directly into the btree at a specific version.
+func setItem(values *btree.BTreeG[dsItem], key []byte, val []byte, version uint64) {
+	values.Set(dsItem{
+		key:     key,
+		val:     val,
+		version: version,
+	})
+}
+
+// TestIteratorForwardFirstKeyOnlyAtNewerVersion tests that a forward iterator
+// using First() does not expose a key that only exists at a version higher than
+// the iterator's snapshot version.
+func TestIteratorForwardFirstKeyOnlyAtNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	// Insert "aaa" only at version 5, and "bbb" at version 1 (visible).
+	setItem(ds.values, []byte("aaa"), []byte("val_aaa"), 5)
+	setItem(ds.values, []byte("bbb"), []byte("val_bbb"), 1)
+
+	// Create a forward iterator with version 3 and no start/end bounds.
+	// This forces restart() to use the First() path.
+	iter := newRangeIter(ds, ds.values, nil, nil, false, 3)
+	defer iter.Close()
+
+	hasItem, err := iter.Next()
+	require.NoError(t, err)
+	require.True(t, hasItem, "should find at least one item")
+
+	// The first item returned must be "bbb" (version 1), not "aaa" (version 5).
+	require.Equal(t, []byte("bbb"), iter.Key())
+}
+
+// TestIteratorReverseLastKeyOnlyAtNewerVersion tests that a reverse iterator
+// using Last() does not expose a key that only exists at a version higher than
+// the iterator's snapshot version.
+func TestIteratorReverseLastKeyOnlyAtNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	// Insert "aaa" at version 1 (visible) and "zzz" only at version 5.
+	setItem(ds.values, []byte("aaa"), []byte("val_aaa"), 1)
+	setItem(ds.values, []byte("zzz"), []byte("val_zzz"), 5)
+
+	// Create a reverse iterator with version 3 and no start/end bounds.
+	// This forces restart() to use the Last() path.
+	iter := newRangeIter(ds, ds.values, nil, nil, true, 3)
+	defer iter.Close()
+
+	hasItem, err := iter.Next()
+	require.NoError(t, err)
+	require.True(t, hasItem, "should find at least one item")
+
+	// The first item returned must be "aaa" (version 1), not "zzz" (version 5).
+	require.Equal(t, []byte("aaa"), iter.Key())
+}
+
+// TestIteratorSeekToKeyOnlyAtNewerVersion tests that Seek() does not expose
+// a key that only exists at a version higher than the iterator's snapshot version.
+func TestIteratorSeekToKeyOnlyAtNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	// Insert "bbb" only at version 5, and "ccc" at version 1 (visible).
+	setItem(ds.values, []byte("bbb"), []byte("val_bbb"), 5)
+	setItem(ds.values, []byte("ccc"), []byte("val_ccc"), 1)
+
+	iter := newRangeIter(ds, ds.values, nil, nil, false, 3)
+	defer iter.Close()
+
+	// Seek to "bbb" which only exists at version 5 — should skip to "ccc".
+	hasItem, err := iter.Seek([]byte("bbb"))
+	require.NoError(t, err)
+	require.True(t, hasItem, "should find at least one item")
+
+	require.Equal(t, []byte("ccc"), iter.Key())
+}
+
+// TestIteratorForwardAllKeysAtNewerVersion tests that a forward iterator
+// correctly returns no items when all keys exist only at versions newer than
+// the iterator's snapshot.
+func TestIteratorForwardAllKeysAtNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	setItem(ds.values, []byte("aaa"), []byte("val_aaa"), 5)
+	setItem(ds.values, []byte("bbb"), []byte("val_bbb"), 6)
+
+	iter := newRangeIter(ds, ds.values, nil, nil, false, 3)
+	defer iter.Close()
+
+	hasItem, err := iter.Next()
+	require.NoError(t, err)
+	require.False(t, hasItem, "should find no items when all versions are newer")
+}
+
+// TestIteratorReverseSeekToKeyOnlyAtNewerVersion tests that a reverse Seek()
+// does not expose a key that only exists at a newer version.
+func TestIteratorReverseSeekToKeyOnlyAtNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	// Insert "aaa" at version 1 (visible), "bbb" only at version 5.
+	setItem(ds.values, []byte("aaa"), []byte("val_aaa"), 1)
+	setItem(ds.values, []byte("bbb"), []byte("val_bbb"), 5)
+
+	iter := newRangeIter(ds, ds.values, nil, nil, true, 3)
+	defer iter.Close()
+
+	// Reverse seek to "bbb" — should skip it and return "aaa".
+	hasItem, err := iter.Seek([]byte("bbb"))
+	require.NoError(t, err)
+	require.True(t, hasItem, "should find at least one item")
+
+	require.Equal(t, []byte("aaa"), iter.Key())
+}
+
+// TestIteratorForwardPrefixKeyOnlyAtNewerVersion tests that a prefix iterator
+// (which uses seek via restart) does not expose keys at newer versions.
+func TestIteratorForwardPrefixKeyOnlyAtNewerVersion(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	// Both keys share prefix "test". "testA" only at version 5, "testB" at version 1.
+	setItem(ds.values, []byte("testA"), []byte("val_A"), 5)
+	setItem(ds.values, []byte("testB"), []byte("val_B"), 1)
+
+	iter := newPrefixIter(ds, ds.values, []byte("test"), false, 3)
+	defer iter.Close()
+
+	hasItem, err := iter.Next()
+	require.NoError(t, err)
+	require.True(t, hasItem, "should find at least one item")
+
+	require.Equal(t, []byte("testB"), iter.Key())
+}

--- a/memory/iter_version_test.go
+++ b/memory/iter_version_test.go
@@ -149,3 +149,28 @@ func TestIteratorForwardPrefixKeyOnlyAtNewerVersion(t *testing.T) {
 
 	require.Equal(t, []byte("testB"), iter.Key())
 }
+
+// TestIteratorReturnsLatestVisibleVersionForMultiVersionKey tests that when a key
+// has multiple versions, the iterator returns the value from the latest version
+// that is still <= the iterator's snapshot version.
+func TestIteratorReturnsLatestVisibleVersionForMultiVersionKey(t *testing.T) {
+	ctx := context.Background()
+	ds := newTestDatastore(ctx)
+
+	// Insert "aaa" at version 1 and version 5. With iter.version=3,
+	// only version 1 should be visible.
+	setItem(ds.values, []byte("aaa"), []byte("val_v1"), 1)
+	setItem(ds.values, []byte("aaa"), []byte("val_v5"), 5)
+
+	iter := newRangeIter(ds, ds.values, nil, nil, false, 3)
+	defer iter.Close()
+
+	hasItem, err := iter.Next()
+	require.NoError(t, err)
+	require.True(t, hasItem, "should find the key at its visible version")
+
+	require.Equal(t, []byte("aaa"), iter.Key())
+	val, err := iter.Value()
+	require.NoError(t, err)
+	require.Equal(t, []byte("val_v1"), val)
+}

--- a/test/integration/iterator/txn_next_value_test.go
+++ b/test/integration/iterator/txn_next_value_test.go
@@ -36,3 +36,65 @@ func TestIteratorTxnNextValue(t *testing.T) {
 
 	test.Execute(t)
 }
+
+func TestIteratorTxnNextValue_WithConcurrentAddition(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), []byte("v3")),
+			action.Set([]byte("k5"), []byte("v5")),
+			action.NewTxn(),
+			action.WithTxn(action.Set([]byte("k2"), []byte("v2"))),
+			action.WithTxn(action.Set([]byte("k4"), []byte("v4"))),
+			action.Set([]byte("k4"), []byte("v44")),
+			action.WithTxn(&action.Iterator{
+				ChildActions: []action.IteratorAction{
+					action.Next(true),
+					action.Value([]byte("v1")),
+					action.Next(true),
+					action.Value([]byte("v2")),
+					action.Next(true),
+					action.Value([]byte("v3")),
+					action.Next(true),
+					action.Value([]byte("v4")),
+					action.Next(true),
+					action.Value([]byte("v5")),
+					action.Next(false),
+				},
+			}),
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorTxnNextValue_WithConcurrentUpdate(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), []byte("v3")),
+			action.Set([]byte("k5"), []byte("v5")),
+			action.NewTxn(),
+			action.WithTxn(action.Set([]byte("k2"), []byte("v2"))),
+			action.WithTxn(action.Set([]byte("k4"), []byte("v4"))),
+			action.Set([]byte("k3"), []byte("v33")),
+			action.WithTxn(&action.Iterator{
+				ChildActions: []action.IteratorAction{
+					action.Next(true),
+					action.Value([]byte("v1")),
+					action.Next(true),
+					action.Value([]byte("v2")),
+					action.Next(true),
+					action.Value([]byte("v3")),
+					action.Next(true),
+					action.Value([]byte("v4")),
+					action.Next(true),
+					action.Value([]byte("v5")),
+					action.Next(false),
+				},
+			}),
+		},
+	}
+
+	test.Execute(t)
+}

--- a/test/integration/iterator/txn_next_value_test.go
+++ b/test/integration/iterator/txn_next_value_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/multiplier"
 )
 
 func TestIteratorTxnNextValue(t *testing.T) {
@@ -39,6 +40,12 @@ func TestIteratorTxnNextValue(t *testing.T) {
 
 func TestIteratorTxnNextValue_WithConcurrentAddition(t *testing.T) {
 	test := &integration.Test{
+		Excludes: []string{
+			// LevelDB can only handle one transaction at a time.
+			// This test is designed to verify that the iterator reflects changes made by
+			// concurrent transactions, which is not applicable to LevelDB.
+			multiplier.Level,
+		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), []byte("v3")),
@@ -70,6 +77,12 @@ func TestIteratorTxnNextValue_WithConcurrentAddition(t *testing.T) {
 
 func TestIteratorTxnNextValue_WithConcurrentUpdate(t *testing.T) {
 	test := &integration.Test{
+		Excludes: []string{
+			// LevelDB can only handle one transaction at a time.
+			// This test is designed to verify that the iterator reflects changes made by
+			// concurrent transactions, which is not applicable to LevelDB.
+			multiplier.Level,
+		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), []byte("v3")),

--- a/test/integration/iterator/txn_reverse_next_value_test.go
+++ b/test/integration/iterator/txn_reverse_next_value_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcenetwork/corekv"
 	"github.com/sourcenetwork/corekv/test/action"
 	"github.com/sourcenetwork/corekv/test/integration"
+	"github.com/sourcenetwork/corekv/test/multiplier"
 )
 
 func TestIteratorTxnReverseNextValue(t *testing.T) {
@@ -43,6 +44,12 @@ func TestIteratorTxnReverseNextValue(t *testing.T) {
 
 func TestIteratorTxnReverseNextValue_WithConcurrentAddition(t *testing.T) {
 	test := &integration.Test{
+		Excludes: []string{
+			// LevelDB can only handle one transaction at a time.
+			// This test is designed to verify that the iterator reflects changes made by
+			// concurrent transactions, which is not applicable to LevelDB.
+			multiplier.Level,
+		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), []byte("v3")),
@@ -77,6 +84,12 @@ func TestIteratorTxnReverseNextValue_WithConcurrentAddition(t *testing.T) {
 
 func TestIteratorTxnReverseNextValue_WithConcurrentUpdate(t *testing.T) {
 	test := &integration.Test{
+		Excludes: []string{
+			// LevelDB can only handle one transaction at a time.
+			// This test is designed to verify that the iterator reflects changes made by
+			// concurrent transactions, which is not applicable to LevelDB.
+			multiplier.Level,
+		},
 		Actions: []action.Action{
 			action.Set([]byte("k1"), []byte("v1")),
 			action.Set([]byte("k3"), []byte("v3")),

--- a/test/integration/iterator/txn_reverse_next_value_test.go
+++ b/test/integration/iterator/txn_reverse_next_value_test.go
@@ -40,3 +40,71 @@ func TestIteratorTxnReverseNextValue(t *testing.T) {
 
 	test.Execute(t)
 }
+
+func TestIteratorTxnReverseNextValue_WithConcurrentAddition(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), []byte("v3")),
+			action.Set([]byte("k5"), []byte("v5")),
+			action.NewTxn(),
+			action.WithTxn(action.Set([]byte("k2"), []byte("v2"))),
+			action.WithTxn(action.Set([]byte("k4"), []byte("v4"))),
+			action.Set([]byte("k4"), []byte("v44")),
+			action.WithTxn(&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				ChildActions: []action.IteratorAction{
+					action.Next(true),
+					action.Value([]byte("v5")),
+					action.Next(true),
+					action.Value([]byte("v4")),
+					action.Next(true),
+					action.Value([]byte("v3")),
+					action.Next(true),
+					action.Value([]byte("v2")),
+					action.Next(true),
+					action.Value([]byte("v1")),
+					action.Next(false),
+				},
+			}),
+		},
+	}
+
+	test.Execute(t)
+}
+
+func TestIteratorTxnReverseNextValue_WithConcurrentUpdate(t *testing.T) {
+	test := &integration.Test{
+		Actions: []action.Action{
+			action.Set([]byte("k1"), []byte("v1")),
+			action.Set([]byte("k3"), []byte("v3")),
+			action.Set([]byte("k5"), []byte("v5")),
+			action.NewTxn(),
+			action.WithTxn(action.Set([]byte("k2"), []byte("v2"))),
+			action.WithTxn(action.Set([]byte("k4"), []byte("v4"))),
+			action.Set([]byte("k3"), []byte("v33")),
+			action.WithTxn(&action.Iterator{
+				IterOptions: corekv.IterOptions{
+					Reverse: true,
+				},
+				ChildActions: []action.IteratorAction{
+					action.Next(true),
+					action.Value([]byte("v5")),
+					action.Next(true),
+					action.Value([]byte("v4")),
+					action.Next(true),
+					action.Value([]byte("v3")),
+					action.Next(true),
+					action.Value([]byte("v2")),
+					action.Next(true),
+					action.Value([]byte("v1")),
+					action.Next(false),
+				},
+			}),
+		},
+	}
+
+	test.Execute(t)
+}


### PR DESCRIPTION
## Relevant issue(s)

Resolves #105 

## Description

This PR solves an bug where the iterator on the memory store would return items of version higher than that defined on the iterator.