### PR TITLE
fix: Avoid memory transaction iterator deadlock

### DIFF
--- a/memory/memory.go
+++ b/memory/memory.go
@@ -36,7 +36,6 @@ type dsItem struct {
 	version   uint64
 	val       []byte
 	isDeleted bool
-	isGet     bool
 }
 
 func byKeys(a, b dsItem) bool {
@@ -197,6 +196,7 @@ func (d *Datastore) newTransaction(readOnly bool) *basicTxn {
 	v := d.getVersion()
 	txn := &basicTxn{
 		ops:       btree.NewBTreeG(byKeys),
+		reads:     btree.NewBTreeG(byKeys),
 		ds:        d,
 		readOnly:  readOnly,
 		dsVersion: &v,
@@ -332,9 +332,6 @@ func (d *Datastore) commit(t *basicTxn) error {
 	iter := t.ops.Iter()
 	v := t.ds.nextVersion()
 	for iter.Next() {
-		if iter.Item().isGet {
-			continue
-		}
 		item := iter.Item()
 		item.version = v
 		t.ds.values.Set(item)

--- a/memory/txn.go
+++ b/memory/txn.go
@@ -21,8 +21,9 @@ import (
 
 // basicTxn implements corekv.Txn
 type basicTxn struct {
-	ops *btree.BTreeG[dsItem]
-	ds  *Datastore
+	ops   *btree.BTreeG[dsItem]
+	reads *btree.BTreeG[dsItem]
+	ds    *Datastore
 	// Version of the datastore when the transaction was initiated.
 	dsVersion *uint64
 	readOnly  bool
@@ -68,18 +69,16 @@ func (t *basicTxn) Delete(ctx context.Context, key []byte) error {
 }
 
 func (t *basicTxn) get(key []byte) dsItem {
-	result := dsItem{}
-	t.ops.Descend(dsItem{key: key, version: t.getTxnVersion()}, func(item dsItem) bool {
-		if bytes.Equal(key, item.key) {
-			result = item
-		}
-		// We only care about the last version so we stop iterating right away by returning false.
-		return false
-	})
+	result := get(t.ops, key, t.getTxnVersion())
+	if result.key == nil {
+		result = get(t.reads, key, t.getDSVersion())
+	}
 	if result.key == nil {
 		result = get(t.ds.values, key, t.getDSVersion())
-		result.isGet = true
-		t.ops.Set(result)
+		if result.key == nil {
+			result = dsItem{key: bytes.Clone(key), isDeleted: true}
+		}
+		t.reads.Set(result)
 	}
 	return result
 }
@@ -198,6 +197,7 @@ func (t *basicTxn) Discard() {
 	}
 
 	t.ops.Clear()
+	t.reads.Clear()
 	t.clearInFlightTxn()
 	t.discarded = true
 }
@@ -226,14 +226,17 @@ func (t *basicTxn) checkForConflicts() error {
 	if t.getDSVersion() == t.ds.getVersion() {
 		return nil
 	}
-	iter := t.ops.Iter()
-	defer iter.Release()
-	for iter.Next() {
-		expectedItem := get(t.ds.values, iter.Item().key, t.getDSVersion())
-		latestItem := get(t.ds.values, iter.Item().key, t.ds.getVersion())
-		if latestItem.version != expectedItem.version {
-			return corekv.ErrTxnConflict
+	for _, items := range []*btree.BTreeG[dsItem]{t.reads, t.ops} {
+		iter := items.Iter()
+		for iter.Next() {
+			expectedItem := get(t.ds.values, iter.Item().key, t.getDSVersion())
+			latestItem := get(t.ds.values, iter.Item().key, t.ds.getVersion())
+			if latestItem.version != expectedItem.version {
+				iter.Release()
+				return corekv.ErrTxnConflict
+			}
 		}
+		iter.Release()
 	}
 	return nil
 }

--- a/memory/txn_test.go
+++ b/memory/txn_test.go
@@ -1,0 +1,85 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcenetwork/corekv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxnGetWhileIteratorOpen(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := NewDatastore(ctx)
+	require.NoError(t, store.Set(ctx, []byte("a"), []byte("first")))
+	require.NoError(t, store.Set(ctx, []byte("b"), []byte("second")))
+
+	txn := store.NewTxn(false)
+	defer txn.Discard()
+	iter, err := txn.Iterator(ctx, corekv.IterOptions{})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, iter.Close())
+	}()
+	requireNextValue(t, iter, []byte("first"))
+
+	type getResult struct {
+		value []byte
+		err   error
+	}
+	result := make(chan getResult, 1)
+	go func() {
+		value, err := txn.Get(ctx, []byte("b"))
+		result <- getResult{value: value, err: err}
+	}()
+
+	select {
+	case got := <-result:
+		require.NoError(t, got.err)
+		require.Equal(t, []byte("second"), got.value)
+	case <-time.After(time.Second):
+		t.Fatal("transaction read blocked while iterator was open")
+	}
+}
+
+func TestTxnReadConflict(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := NewDatastore(ctx)
+	require.NoError(t, store.Set(ctx, []byte("key"), []byte("old")))
+
+	txn := store.NewTxn(false)
+	value, err := txn.Get(ctx, []byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("old"), value)
+
+	require.NoError(t, store.Set(ctx, []byte("key"), []byte("new")))
+	require.ErrorIs(t, txn.Commit(), corekv.ErrTxnConflict)
+}
+
+func TestTxnMissingReadConflict(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store := NewDatastore(ctx)
+	txn := store.NewTxn(false)
+	_, err := txn.Get(ctx, []byte("key"))
+	require.ErrorIs(t, err, corekv.ErrNotFound)
+
+	require.NoError(t, store.Set(ctx, []byte("key"), []byte("new")))
+	require.ErrorIs(t, txn.Commit(), corekv.ErrTxnConflict)
+}
+
+func requireNextValue(t *testing.T, iter corekv.Iterator, expected []byte) {
+	t.Helper()
+	ok, err := iter.Next()
+	require.NoError(t, err)
+	require.True(t, ok)
+	value, err := iter.Value()
+	require.NoError(t, err)
+	require.Equal(t, expected, value)
+}


### PR DESCRIPTION
## Summary

- keep transaction reads in a separate B-tree from pending writes
- allow reads while a transaction iterator is open without mutating its write overlay
- preserve conflict detection for existing and missing keys

This addresses the transaction deadlock described in #59: a transaction iterator holds the write-overlay read lock, while a read through the same transaction previously tried to record itself in that locked tree.

## Verification

- `make test:memory`
- `go test -race ./...` in the memory module
- regression coverage for reads during iteration and read conflicts